### PR TITLE
Rollback on providerURL + JWKS in memory + PEM keys in env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .dynamodb/
 .env
 .env.test
+!.env_vars.sample
 .eslintcache
 .fusebox/
 .grunt

--- a/client/.env_vars.sample
+++ b/client/.env_vars.sample
@@ -1,0 +1,3 @@
+export PEM_RSA_PRIVATE_KEY_1=
+export PEM_RSA_PRIVATE_KEY_2=
+export PEM_RSA_PUBLIC_KEY= 

--- a/client/.env_vars.sample
+++ b/client/.env_vars.sample
@@ -1,3 +1,4 @@
 export PEM_RSA_PRIVATE_KEY_1=
 export PEM_RSA_PRIVATE_KEY_2=
-export PEM_RSA_PUBLIC_KEY= 
+export PEM_RSA_PUBLIC_KEY=
+ 

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.2] - 2021-01-28
+
+- Changed back `openIDConfigurationURL` to `providerURL` in the `oauth2Client` constructor.
+- Storing `JWKS` in the `oauth2Client` for performances.
+
 ## [0.2.1] - 2021-01-14
 
 - Added an optional property (`openIDConfiguration`) to the `oauth2Client` constructor.
+- Changed `openIDConfigurationURL` to `providerURL` in the `oauth2Client` constructor.
 
 ## [0.2.0] - 2021-01-13
 

--- a/client/README.md
+++ b/client/README.md
@@ -16,7 +16,7 @@ yarn add @fewlines/connect-client
 
 You first need to initialize the client instance, called `OAuth2Client`. This class takes the following constructor parameters:
 
-- `providerURL`: The base URL corresponding to the Provider.
+- `openIDConfigurationURL`: The URL to retrieve the OpenID configuration.
 - `clientID`: Client ID of the online service (e.g. internet website, application) that uses the Provider Authentication and Authorization service for its User.
 - `clientSecret`: Paired with the client ID, used to authenticate the Application from which the User intent to sign in.
 - `redirectURI`: URI used to redirect to the original Application website after a successful login in on Connect.
@@ -30,7 +30,7 @@ import OAuth2Client, {
 } from "@fewlines/connect-client";
 
 const oauthClientConstructorProps: OAuth2ClientConstructor = {
-  providerURL: "***",
+  openIDConfigurationURL: "***",
   clientID: "***",
   clientSecret: "***",
   redirectURI: "***",

--- a/client/index.ts
+++ b/client/index.ts
@@ -29,7 +29,7 @@ import { generateHS256JWS, generateRS256JWS } from "./src/utils/generateJWS";
 import { rsaPublicKeyToPEM } from "./src/utils/rsaPublicKeyToPEM";
 
 class OAuth2Client {
-  readonly providerURL: string;
+  readonly openIDConfigurationURL: string;
   readonly clientID: string;
   readonly clientSecret: string;
   readonly redirectURI: string;
@@ -37,9 +37,10 @@ class OAuth2Client {
   readonly scopes: string[];
   private fetch: any;
   openIDConfiguration?: OpenIDConfiguration;
+  jwks?: JWKSDT;
 
   constructor({
-    providerURL,
+    openIDConfigurationURL,
     clientID,
     clientSecret,
     redirectURI,
@@ -48,7 +49,7 @@ class OAuth2Client {
     fetch,
     openIDConfiguration,
   }: OAuth2ClientConstructor) {
-    this.providerURL = providerURL;
+    this.openIDConfigurationURL = openIDConfigurationURL;
     this.clientID = clientID;
     this.clientSecret = clientSecret;
     this.redirectURI = redirectURI;
@@ -64,13 +65,7 @@ class OAuth2Client {
     if (this.openIDConfiguration) {
       return Promise.resolve();
     } else {
-      const route = ".well-known/openid-configuration";
-      const openIDConfigurationURL = new URL(
-        route,
-        this.providerURL,
-      ).toString();
-
-      await this.fetch(openIDConfigurationURL)
+      await this.fetch(this.openIDConfigurationURL)
         .then((response) => response.json())
         .then((openIDConfiguration) => {
           this.openIDConfiguration = openIDConfiguration;
@@ -81,16 +76,21 @@ class OAuth2Client {
     }
   }
 
-  private async getJWKS(): Promise<JWKSDT> {
+  private async getJWKS(): Promise<void> {
     await this.setOpenIDConfiguration();
 
-    const JWKS: JWKSDT = await this.fetch(this.openIDConfiguration.jwks_uri)
-      .then((response) => response.json())
-      .catch((error) => {
-        throw error;
-      });
-
-    return JWKS;
+    if (this.jwks) {
+      return Promise.resolve();
+    } else {
+      await this.fetch(this.openIDConfiguration.jwks_uri)
+        .then((response) => response.json())
+        .then((jwks) => {
+          this.jwks = jwks;
+        })
+        .catch((error) => {
+          throw error;
+        });
+    }
   }
 
   async getAuthorizationURL(state?: string): Promise<URL> {
@@ -167,8 +167,7 @@ class OAuth2Client {
 
   async verifyJWT<T = unknown>(accessToken: string, algo: string): Promise<T> {
     await this.setOpenIDConfiguration();
-
-    const JWKS = await this.getJWKS();
+    await this.getJWKS();
 
     return new Promise((resolve, reject) => {
       const [header, payload] = accessToken.split(".");
@@ -196,8 +195,8 @@ class OAuth2Client {
         );
       } else if (alg === "RS256" && algo === "RS256") {
         if (kid) {
-          if (JWKS) {
-            const validKey = JWKS.keys.find(
+          if (this.jwks) {
+            const validKey = this.jwks.keys.find(
               (keyObject) => keyObject.kid === kid,
             );
 
@@ -269,10 +268,7 @@ class OAuth2Client {
       scope: this.scopes.join(" "),
     };
 
-    const route = "oauth/token";
-    const absoluteURL = new URL(route, this.providerURL).toString();
-
-    return this.fetch(absoluteURL, {
+    return this.fetch(this.openIDConfiguration.token_endpoint, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/client/index.ts
+++ b/client/index.ts
@@ -76,7 +76,7 @@ class OAuth2Client {
     }
   }
 
-  private async getJWKS(): Promise<void> {
+  private async setJWKS(): Promise<void> {
     await this.setOpenIDConfiguration();
 
     if (this.jwks) {
@@ -167,7 +167,7 @@ class OAuth2Client {
 
   async verifyJWT<T = unknown>(accessToken: string, algo: string): Promise<T> {
     await this.setOpenIDConfiguration();
-    await this.getJWKS();
+    await this.setJWKS();
 
     return new Promise((resolve, reject) => {
       const [header, payload] = accessToken.split(".");

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-client",
-  "version": "0.2.1",
+  "version": "0.0.0-experimental-4f3d99c",
   "author": "Fewlines",
   "description": "OAuth2 Client for the Connect JS SDK",
   "license": "MIT",

--- a/client/package.json
+++ b/client/package.json
@@ -19,8 +19,7 @@
     "prepublishOnly": "yarn lint",
     "experimental-publish": "yarn publish --new-version \"0.0.0-experimental-$(git rev-parse --short HEAD)\" --access public --tag experimental",
     "preversion": "yarn lint",
-    "test": "jest",
-    "experimental-publish": "yarn publish --new-version \"0.0.0-experimental-$(git rev-parse --short HEAD)\" --access public --tag experimental"
+    "test": "jest"
   },
   "dependencies": {
     "jsonwebtoken": "8.5.1",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-client",
-  "version": "0.0.0-experimental-4f3d99c",
+  "version": "0.2.2",
   "author": "Fewlines",
   "description": "OAuth2 Client for the Connect JS SDK",
   "license": "MIT",

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -19,7 +19,7 @@ export type OpenIDConfiguration = {
 };
 
 export type OAuth2ClientConstructor = {
-  providerURL: string;
+  openIDConfigurationURL: string;
   clientID: string;
   clientSecret: string;
   redirectURI: string;

--- a/client/tests/generateJWS.test.ts
+++ b/client/tests/generateJWS.test.ts
@@ -73,37 +73,9 @@ describe("generateJWS", () => {
     test("should generate an RS256 signed JWS when passing a custom payload and custom privateKey", () => {
       expect.assertions(2);
 
-      const customPrivateKey = `-----BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEAxjZtuBv6NLuYOME+R35ZAnRlqeUwgsseNeUE91MRn0cl2auy
-5g6GtmTCW5jgDWs0gqqa61p2w+yj5ecNRdkxK8r5qij7PBEeZZ73F6+Kni2i9b6X
-x1HSdgdq9jSsTt6OqKanoANl3x4wfvFD/f2Knfl5c0Q+Iq5iC7rHUV5fM0TUsLdM
-FyujcD93WSBFeD2GlCLIWW6Hxp6LwzliD8YdLcAOccmI+4GP7zXr4KURZ9jzYW2L
-wQQspjHswVbipE8YlIpsubsmB/TGLlqnCX3MF4+cNgx9JoKBTTGvzu5uNE9wrI+7
-43k27eKMrL0sLYwJv+LhP0lz1+kG078wskS0hwIDAQABAoIBAC0BtN4mNCT/J6xT
-bLHNJabiCSePq/k259AzBXKnQQwamqSXURLd34bQ0DT+PHmviwfUd0LTkr4gIIMW
-eLQQghLAjvotPgbAmFdYxiBxspcCI8uLEGmo0ZINUyM+iJWMAXaYCN3Th7Em6Loa
-TGcCyBPgzsv2helYEVk6ewGl3RYFtxheKlzq5xBtoNeInfm05IpFseEBZsofMYfJ
-+I7vfMERVY/KeqZMtdM+j6o+0TKt5vFcKPBDZAhNbE0JpRbOf61jBL3d64oYoCuV
-5DfM0SSc/wLaDEjPUCGw5I59LbJayfFyRyfVUmvkxgYbFb5dJORZdwWQLjiaX9n/
-T5uY+FECgYEA/AKTcgHkVWraSTX8SCcbFo9fdNeVvxIlf9Mh1ldi/jnel8X67Lw3
-IT7+HUKW+1tCE4c2TYxANF870ZQ7U1KwtnLbqUD48A/+uzY4gbGhoyU4JRDZK/u7
-Ha7MxjUg7Z6UNpANv1vtQ9+WEXtk2S1eMCxD016n07887+PwgRaSDt8CgYEAyVnO
-RVficWthehYcItk/gbNaigvc4cLNqF3Jranmv1zIsokxkoxoAJ+X1ixD32uvxhyr
-dlmTFzJPS0kUtfdt//AgKhuOzQMN5iah5lnAclhWMucunkYn7ydDEdUW3tlU1ClW
-ZoiJR1AqjtunfuU5RLWXZHXdepR9fuOSuPxIl1kCgYEAq4cZUq0E/DqpbtFG8Nll
-L5rQjxe5vf6c9X8AdgKux3keD9Hac827/G4CymmrmFRKCj6q8Gd4v+zeK00ogBM1
-YkmVR4OIrOVGLai/F0+PRBsuNtRb7Pr/Jjn2+SXqTrH0EZtFMC1itiL14tpJDyU5
-CbLnS3QO6SouUN2lskdpjKMCgYAPRPo5lAKeK1CHG6oikmsYgOt60I99p3JFNGeY
-/et706N8tp7FyFQSyAeRvGWhSd9YnM/796sJ9UzCHtatPghfgmxOBSz9KyAgtglN
-GL1Zbo2K6rFEW3mnz0hsz8YePEkMld3xhKU0fUXc85duLh/7r/G9MpsLMruZpdR4
-ptkycQKBgFNjDJu+aAt+1OnlZcne6pvTbkXyYAoPcCbgj8oS4SV6gB7fYP5/POAn
-V6JGeHdSp+rHxMpmDMBTph+/gcLbxp2hQr/pjo8sidoewkp3sT5CoHNS/dvYEFon
-DuPT/XKDVlCokjlGegyaAEKQJuitiDuLFYHw33bnl2qyADl2/Z9c
------END RSA PRIVATE KEY-----`;
-
       const RS256JWS = generateRS256JWS(
         { ...defaultPayload, ...customPayload },
-        customPrivateKey,
+        process.env.PEM_RSA_PRIVATE_KEY,
       );
 
       const [JWA, payload] = RS256JWS.split(".");

--- a/client/tests/generateJWS.test.ts
+++ b/client/tests/generateJWS.test.ts
@@ -70,12 +70,12 @@ describe("generateJWS", () => {
       );
     });
 
-    test("should generate an RS256 signed JWS when passing a custom payload and custom privateKey", () => {
+    test("should generate a RS256 signed JWS when passing a custom payload and custom privateKey", () => {
       expect.assertions(2);
 
       const RS256JWS = generateRS256JWS(
         { ...defaultPayload, ...customPayload },
-        process.env.PEM_RSA_PRIVATE_KEY,
+        process.env.PEM_RSA_PRIVATE_KEY_1,
       );
 
       const [JWA, payload] = RS256JWS.split(".");

--- a/client/tests/index.test.ts
+++ b/client/tests/index.test.ts
@@ -25,7 +25,7 @@ describe("OAuth2Client", () => {
   });
 
   const oauthClientConstructorProps: OAuth2ClientConstructor = {
-    providerURL: "http://mocked-openid-url.test",
+    openIDConfigurationURL: "http://mocked-openid-url.test",
     clientID: "7dc44ab1-177a-459f-8be5-e485f16c8e87",
     clientSecret: defaultSecret,
     redirectURI: "http://mocked-redirect-url.test",
@@ -432,6 +432,9 @@ describe("OAuth2Client", () => {
         },
       });
 
+      console.log("publicKeyForEncryption: ", publicKeyForEncryption);
+      console.log("privateKeyForEncryption: ", privateKeyForEncryption);
+
       const mockedSignedJWT = jwt.sign(defaultPayload, privateKeyForSignature);
 
       const josePublicKeyForEncryption = await jose.JWK.asKey(
@@ -470,37 +473,9 @@ describe("OAuth2Client", () => {
       const mockedJWEAccessToken =
         "eyJhbGciOiJSU0EtT0FFUC0yNTYiLCJlbmMiOiJBMTI4R0NNIn0.w4eo3k66Kr20CVrUQYDCgIR9ZFTFmbdtHvCGEGEYqQt3xJKo1zDT8nrkApHBTWgpg09BrvToBcHYhpZSCV9dbMSzjPWvjNlQTr5f7lOQ4Q34MQaCmH3LWr5toCYGl9iXJLolpW-r9vQNuwJIoYIinycXYJMCMgT72miKbHC66qJf1YoOgOqC9fc8E4V79fYuAaLmalEncqJHTn_u67e5qEZNqRrgFlxd4b9IPhMuRmaP3OICvtSFBIuFH64gVke6ckOwK-mGIIA-qQzwgkZrWnddmIMWKhSR7CwtXzKY46alHJrN1pvaAHBVqHCKi3JtBL_sCtpVZXHfCmhBqWcW2A.vxelVyonD7vTWBYX.yz7wOYxlwTRGeuABqlQ110Sw28nFsHjBig9kwyGFz4D6fqjrY_6mM2fYBZDbPuviumQifJ3vDvilV4dkIXJ9csSEgLlaLOK043kpT2T-2_XFnxdG7sfBHRimsg_ag889OjdZiGT4hMK-K_0lyZ8dOTHgcRMpLApX_s8Cog.kxPk7co7dttJ9l9ZrKxV9g";
 
-      const mockedPrivateKey = `-----BEGIN RSA PRIVATE KEY-----
-        MIIEogIBAAKCAQEAyI/9q9TjkglfDJebAjC5vt6HFZYthcU2rc2/4bIETIUkwDcf
-        PoTrSFarccZ9pl9bAXlMfKhc6LcRB6XcBWACeDoblbgMzaZ/4rTUGrReUHB0HpmZ
-        kyXDkN8iezTNG2gKRhVrS2rjlpLKMIDKVfG/xXsNQmT4iVs07MBSJToTKT2lIzbE
-        u4sEZz9GUhwffeKBmh3uxX+ELxpp++eShD3pGPo5l3mkozEYRpa5tK2aXHfgNm1+
-        KLkWq9uNd+msj/4lC0AxQ5a8re4z5zP2IJoN9buJqvV7e8lpKoAPJ76jcBEEeZBD
-        LNvP+ZXcSRkhj6l/cJjYgQcr8DtoJ97F0MWlywIDAQABAoIBABCP837RIcnZhEPh
-        8ScJJw2gCr+5myDE3HMV3pagwMIg7JwC8U2UZGmg3p+SqKWokjdY8PwKW0HMfFeJ
-        VtYKy6lqAwUmIciJy13JWQqrgm5aGvy76nbAU5oPEyXhgl6VBOQsuKONvCWfEZtX
-        x125jQCd3MZy2CNfqMs0RpRUa2ioTSI2JWJnqsYuNEHysgCL9+jtEqDm62Qmp4nG
-        F02+EZilu8wM5XOKkv7Q/zsSimjTP5rXxAVhvlUvsJGTj67fFRnoY4LmAkSramgO
-        CHgvb3+GjiCbu4WFFf06P89dvt5Q6OtjWJEojmgbrrmjk9ccBtD4wtIS/JfbuIMF
-        jnDVMqECgYEA4pyN9pQGuXutEYZ4wAi8FR++ruNbPscuorUID/uW137H3oTuLXig
-        L2u64F7JQ9692sXfecmL53goY2+qSNo7xdfBSoF0q8MLlWL0VhU6S9vYHqa2TjDX
-        WPzNuQWIlxWzKTUVj0Jfw5TBbri+PaTn4hMEPCqkzbdW2sK4XZ0zU+cCgYEA4pKd
-        F+t825Prxqsky1e6vfwfgdLuhZeBRLPHzssAB0GtsvhmsBj36JmU/OdPXDKIPShO
-        fx0/jRmuureja+uNlXUUsBxQXfz4O5XS/otIsI3GxO415kezRNvB/eLAogO4JTvz
-        zH1B+1VnsBpealFQYGSZ6xqCN94OunyDnjPHIn0CgYBQPasvEr9G0no36Gu9Y9pl
-        iHYWqz7V/eWPi5atQiLpb2UKb/t+cmYWJIlphWay9542ZzZ4g1tcvPlgLFwZq9za
-        c0loPmq3nzrszLtD+ARKdDAUumd3TGgUhH+78i+pf++OudNGhPQv5u6PbC9A2LGb
-        JaysOVVd2nuQvr5Vt6JDJQKBgGwU4omJlXstmhighaHWzMdaYTFODOh/eHPsixEz
-        t2S+yPyKEHpKvuAfe3oVYb8qf+EkvCVZL3rA2KBLf9K4gEbenirQpunfBg9ujkNM
-        8DUAvOQuelnKtFLRvj29kIT43zwr2EYhLnuVpyvTuFxhQ8Vn2CDV+W5rKH1/bk3m
-        h0UFAoGAOWOocpeq5LpV0IYjvGUqPol/eVLU8TjHcesPbRpyYGPx6GgG2yFAtvQT
-        q/PrBnwqO+Qfe+TRkMPuCpvUFwZq7ytKlPiBCV5LqdmhoouZtA9fCulK47kwRQQt
-        8GdyvRZzfC3P2vdaezSk3Wv3bqhXmu7R4JXx+jFg1mao/i+BwfM=
-        -----END RSA PRIVATE KEY-----`;
-
       const decryptedMockedJWEAccessToken = await oauthClient.decryptJWE<{
         iss: string;
-      }>(mockedJWEAccessToken, mockedPrivateKey, false);
+      }>(mockedJWEAccessToken, process.env.PEM_RSA_PRIVATE_KEY, false);
 
       expect(decryptedMockedJWEAccessToken.iss).toStrictEqual(
         mockedAccessTokenClearPayload.iss,

--- a/client/tests/index.test.ts
+++ b/client/tests/index.test.ts
@@ -432,9 +432,6 @@ describe("OAuth2Client", () => {
         },
       });
 
-      console.log("publicKeyForEncryption: ", publicKeyForEncryption);
-      console.log("privateKeyForEncryption: ", privateKeyForEncryption);
-
       const mockedSignedJWT = jwt.sign(defaultPayload, privateKeyForSignature);
 
       const josePublicKeyForEncryption = await jose.JWK.asKey(
@@ -475,7 +472,7 @@ describe("OAuth2Client", () => {
 
       const decryptedMockedJWEAccessToken = await oauthClient.decryptJWE<{
         iss: string;
-      }>(mockedJWEAccessToken, process.env.PEM_RSA_PRIVATE_KEY, false);
+      }>(mockedJWEAccessToken, process.env.PEM_RSA_PRIVATE_KEY_2, false);
 
       expect(decryptedMockedJWEAccessToken.iss).toStrictEqual(
         mockedAccessTokenClearPayload.iss,

--- a/client/tests/rsaPublicKeyToPEM.test.ts
+++ b/client/tests/rsaPublicKeyToPEM.test.ts
@@ -14,12 +14,6 @@ describe("rsaPublicKeyToPEM", () => {
     const { e, n } = validKey;
     const publicKey = rsaPublicKeyToPEM(n, e);
 
-    const expectedKey = `-----BEGIN RSA PUBLIC KEY-----
-MIGJAoGBAMtzOyamOPSXi/6K5z+2WNkJTu+mpEt+kY9YilUiJRR++eDZ6prRsDKw
-lWcwlq3PPNra2xrg4ZpdqbDpgiAYygaZ4ITSwWQCxjUXpQqn1ewsvhDK0L0PlFm6
-IE+8Xz6C/lWIwmSk3l6LH8zDTGRbpv1Z5P72ASopV2X0B9beLKIVAgMBAAE=
------END RSA PUBLIC KEY-----`;
-
-    expect(publicKey).toMatch(expectedKey);
+    expect(publicKey).toMatch(process.env.PEM_RSA_PUBLIC_KEY);
   });
 });


### PR DESCRIPTION
This PR goal is to change `providerURL` back to `openIDConfigurationURL`, adding JWKS storage in memory and putting private/public tests keys in environment variables.