### PR TITLE
Fixing issues with last version of the package

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.5] - 2021-02-09
+
+- Fixing issues with `getOpenIDConfiguration`, `getJWKS` and `verifyJWT`.
+
 ## [0.2.4] - 2021-02-08
 
 - Optimising the storage and the fetching of `JWKS` and `openIDConfiguration`.

--- a/client/index.ts
+++ b/client/index.ts
@@ -174,7 +174,7 @@ class OAuth2Client {
     const { alg, kid } = decodeJWTPart<{ alg: string; kid: string }>(header);
     const { aud } = decodeJWTPart<{ aud: string }>(payload);
 
-    const jwks = kid && await this.getJWKS();
+    const jwks = kid && (await this.getJWKS());
 
     return new Promise((resolve, reject) => {
       if (

--- a/client/index.ts
+++ b/client/index.ts
@@ -65,7 +65,7 @@ class OAuth2Client {
     if (this.openIDConfiguration) {
       return Promise.resolve(this.openIDConfiguration);
     } else {
-      await this.fetch(this.openIDConfigurationURL)
+      return await this.fetch(this.openIDConfigurationURL)
         .then((response) => response.json())
         .then((openIDConfiguration) => {
           this.openIDConfiguration = openIDConfiguration;
@@ -87,7 +87,7 @@ class OAuth2Client {
     if (this.jwks) {
       return Promise.resolve(this.jwks);
     } else {
-      await this.fetch(openIDConfiguration.jwks_uri)
+      return await this.fetch(openIDConfiguration.jwks_uri)
         .then((response) => response.json())
         .then((jwks) => {
           this.jwks = jwks;

--- a/client/index.ts
+++ b/client/index.ts
@@ -173,7 +173,7 @@ class OAuth2Client {
 
     const { alg, kid } = decodeJWTPart<{ alg: string; kid: string }>(header);
     const { aud } = decodeJWTPart<{ aud: string }>(payload);
-    let jwks;
+    let jwks = this.jwks;
 
     if (kid) {
       if (!this.jwks) {

--- a/client/index.ts
+++ b/client/index.ts
@@ -173,13 +173,8 @@ class OAuth2Client {
 
     const { alg, kid } = decodeJWTPart<{ alg: string; kid: string }>(header);
     const { aud } = decodeJWTPart<{ aud: string }>(payload);
-    let jwks = this.jwks;
 
-    if (kid) {
-      if (!this.jwks) {
-        jwks = await this.getJWKS();
-      }
-    }
+    const jwks = kid && await this.getJWKS();
 
     return new Promise((resolve, reject) => {
       if (

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-client",
-  "version": "0.2.4",
+  "version": "0.0.0-experimental-99bfe17",
   "author": "Fewlines",
   "description": "OAuth2 Client for the Connect JS SDK",
   "license": "MIT",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-client",
-  "version": "0.0.0-experimental-99bfe17",
+  "version": "0.2.5",
   "author": "Fewlines",
   "description": "OAuth2 Client for the Connect JS SDK",
   "license": "MIT",


### PR DESCRIPTION
* The two getters `getOpenIDConfiguration` and `getJWKS` were missing a return statement, which resulted on `openIDConfiguration` and `jwks` being `undefined`. 


* Second issue was located on `verifyJWT`, where `jwks` happened to be `undefined` the second time it is called. The variable used inside the function is now initiated with the corresponding class property `this.jwks`