### PR TITLE
Public key rotation support + content-type fix on refreshToken + some refacto

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2021-02-15
+
+- Added retry of JWT verification to handle public key rotation.
+
 ## [0.2.5] - 2021-02-09
 
 - Fixing issues with `getOpenIDConfiguration`, `getJWKS` and `verifyJWT`.

--- a/client/index.ts
+++ b/client/index.ts
@@ -265,9 +265,9 @@ class OAuth2Client {
     return this.fetch(openIDConfiguration.token_endpoint, {
       method: "POST",
       headers: {
-        "Content-Type": "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
       },
-      body: JSON.stringify(payload),
+      body: new URLSearchParams(payload),
     }).then((response) => response.json());
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-client",
-  "version": "0.2.5",
+  "version": "0.0.0-experimental-69757fd",
   "author": "Fewlines",
   "description": "OAuth2 Client for the Connect JS SDK",
   "license": "MIT",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-client",
-  "version": "0.0.0-experimental-69757fd",
+  "version": "0.0.0-experimental-d245d22",
   "author": "Fewlines",
   "description": "OAuth2 Client for the Connect JS SDK",
   "license": "MIT",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-client",
-  "version": "0.0.0-experimental-d245d22",
+  "version": "0.3.0",
   "author": "Fewlines",
   "description": "OAuth2 Client for the Connect JS SDK",
   "license": "MIT",


### PR DESCRIPTION
In this PR, I did different things: 

I changed the `content-type` when we fetch the `token_endpoint` in the `refreshTokens` flow.

To implement retry of access token verification, in case of a public key rotation, some refacto was necessary. First, we need now, when we don't find a valid key among the JWKS, to refetch JWKS endpoint, even if `this.jwks` is already set. So, I separate the previous method in two part : 
* `getJWKS` now checks if `this.jwks` exists and return it, or if it doesn't, call `this.fetchJWKS`.
* `fetchJWKS` now fetch JWKS endpoint, and set new JWKS in memory.

A bit of logic has been extracted from `verifyJWT`, mostly in new private methods in oauthClient class.
 
* To prevent the need to return a `new Promise()` constructor, I extracted the two blocks which verify HS256 & RS256 JWT into their own private methods: `verifyRS256` & `verifyHS256`. All errors are now thrown directly inside `verifyJWT`. 

* I also extracted the logic of checking if we can find a valid key among the jwks relative to the current access token kid. This new private method `getPublicKey`, check this and return a PEM formatted public key if a valid key is found, or undefined otherwise.  


