### PR TITLE
Update identity

### DIFF
--- a/management/CHANGELOG.md
+++ b/management/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.3.1] - 2021-02-18
+## [0.3.0] - 2021-02-18
 
-- New function called `updateIdentity`, that handle the rollback of the process in case of an exception raised.
+- New function called `updateIdentity`, that handles the rollback of the process in case of an exception raised.
 
 ## [0.2.1] - 2021-02-12
 

--- a/management/CHANGELOG.md
+++ b/management/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.1] - 2021-02-18
+
+- New function called `updateIdentity`, that handle the rollback of the process in case of an exception raised.
+
 ## [0.2.1] - 2021-02-12
 
 - `fetchManagement` now throws a `ConnectUnreachableError` error, derived from `FetchError` (`@types/node-fetch`).

--- a/management/package.json
+++ b/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-management",
-  "version": "0.2.1",
+  "version": "0.3.1",
   "author": "Fewlines",
   "description": "Management flow for the Connect JS SDK",
   "license": "MIT",

--- a/management/package.json
+++ b/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-management",
-  "version": "0.3.1",
+  "version": "0.3.0",
   "author": "Fewlines",
   "description": "Management flow for the Connect JS SDK",
   "license": "MIT",

--- a/management/src/commands/index.ts
+++ b/management/src/commands/index.ts
@@ -6,3 +6,4 @@ export * from "./mark-identity-as-primary";
 export * from "./remove-identity-from-user";
 export * from "./send-identity-validation-code";
 export * from "./update-connect-application";
+export * from "./update-identity";

--- a/management/src/commands/update-identity.ts
+++ b/management/src/commands/update-identity.ts
@@ -60,7 +60,7 @@ async function updateIdentity(
         const identity = {
           userId,
           identityType: type,
-          identityValue: identityToUpdate.value,
+          identityValue: value,
         };
 
         await removeIdentityFromUser(managementCredentials, identity);

--- a/management/src/commands/update-identity.ts
+++ b/management/src/commands/update-identity.ts
@@ -14,7 +14,6 @@ type VerifyValidationCodeData = {
 type NewIdentityData = {
   value: string;
   type: IdentityTypes;
-  primary: string;
 };
 
 async function updateIdentity(
@@ -25,7 +24,7 @@ async function updateIdentity(
   identityToUpdateId: string,
 ): Promise<void> {
   const { validationCode, eventId } = verifyValidationCode;
-  const { value, type, primary } = newIdentity;
+  const { value, type } = newIdentity;
 
   const identityToUpdate = await getIdentity(managementCredentials, {
     userId,
@@ -54,7 +53,7 @@ async function updateIdentity(
     identityValue: value,
   });
 
-  if (primary) {
+  if (identityToUpdate.primary) {
     await markIdentityAsPrimary(managementCredentials, identityId).catch(
       async (error) => {
         const identity = {

--- a/management/src/commands/update-identity.ts
+++ b/management/src/commands/update-identity.ts
@@ -1,0 +1,68 @@
+import { IdentityNotFoundError, InvalidValidationCodeError } from "../errors";
+import { checkVerificationCode } from "../queries/check-verification-code";
+import { getIdentity } from "../queries/get-identity";
+import { IdentityTypes, ManagementCredentials } from "../types";
+import { addIdentityToUser } from "./add-identity-to-user";
+import { markIdentityAsPrimary } from "./mark-identity-as-primary";
+import { removeIdentityFromUser } from "./remove-identity-from-user";
+
+type VerifyValidationCodeProps = {
+  validationCode: string;
+  eventId: string;
+};
+
+type NewIdentityData = {
+  value: string;
+  type: IdentityTypes;
+  primary: string;
+};
+
+async function updateIdentity(
+  managementCredentials: ManagementCredentials,
+  userId: string,
+  verifyValidationCode: VerifyValidationCodeProps,
+  newIdentity: NewIdentityData,
+  identityToUpdateId: string,
+): Promise<void> {
+  const { validationCode, eventId } = verifyValidationCode;
+  const { value, type, primary } = newIdentity;
+
+  const { status: verificationStatus } = await checkVerificationCode(
+    managementCredentials,
+    {
+      code: validationCode,
+      eventId,
+    },
+  );
+
+  if (verificationStatus !== "VALID") {
+    throw new InvalidValidationCodeError();
+  }
+
+  const { id: identityId } = await addIdentityToUser(managementCredentials, {
+    userId,
+    identityType: type,
+    identityValue: value,
+  });
+
+  if (primary) {
+    await markIdentityAsPrimary(managementCredentials, identityId);
+  }
+
+  const identityToUpdate = await getIdentity(managementCredentials, {
+    userId,
+    identityId: identityToUpdateId,
+  });
+
+  if (!identityToUpdate) {
+    throw new IdentityNotFoundError();
+  }
+
+  await removeIdentityFromUser(managementCredentials, {
+    userId,
+    identityType: type,
+    identityValue: identityToUpdate.value,
+  });
+}
+
+export { updateIdentity };

--- a/management/src/errors.ts
+++ b/management/src/errors.ts
@@ -54,7 +54,7 @@ class InvalidValidationCodeError extends Error {
 }
 
 class IdentityNotFoundError extends Error {
-  readonly message = "Invalid validation code";
+  readonly message = "Identity Not Found";
 }
 
 export {

--- a/management/src/errors.ts
+++ b/management/src/errors.ts
@@ -49,6 +49,14 @@ class ConnectUnreachableError extends Error {
   }
 }
 
+class InvalidValidationCodeError extends Error {
+  readonly message = "Invalid validation code";
+}
+
+class IdentityNotFoundError extends Error {
+  readonly message = "Invalid validation code";
+}
+
 export {
   ConnectUnreachableError,
   GraphqlError,
@@ -57,4 +65,6 @@ export {
   InvalidPasswordInputError,
   IdentityAlreadyUsedError,
   IdentityValueCantBeBlankError,
+  InvalidValidationCodeError,
+  IdentityNotFoundError,
 };

--- a/management/tests/commands/index.test.ts
+++ b/management/tests/commands/index.test.ts
@@ -7,6 +7,7 @@ import {
   removeIdentityFromUser,
   sendIdentityValidationCode,
   updateProviderApplication,
+  updateIdentity,
 } from "../../index";
 
 describe("Commands", () => {
@@ -19,5 +20,6 @@ describe("Commands", () => {
     expect(removeIdentityFromUser).toBeInstanceOf(Function);
     expect(sendIdentityValidationCode).toBeInstanceOf(Function);
     expect(updateProviderApplication).toBeInstanceOf(Function);
+    expect(updateIdentity).toBeInstanceOf(Function);
   });
 });


### PR DESCRIPTION
This PR aims at adding a function to handle the update of an Identity, and rollback the process in case of an exception raised.

The client will need to run the `sendIdentityValidationCode` mutation before running it.

I will add a lengthy section regarding this in the documentation is you think my proposition is good.