### PR TITLE
Cu et4ya1 fix identity type in update identity

### DIFF
--- a/management/CHANGELOG.md
+++ b/management/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.1] - 2021-02-24
+
+- Fixed Identity type in `updateIdentity`.
+
 ## [0.4.0] - 2021-02-22
 
 - Refactored `updateIdentity` props (cf. documentation).

--- a/management/README.md
+++ b/management/README.md
@@ -445,3 +445,4 @@ Here are the expected exception raised in case of a failure:
 - GraphqlErrors
 - IdentityNotFoundError
 - InvalidValidationCodeError
+- UnhandledIdentityType

--- a/management/README.md
+++ b/management/README.md
@@ -116,7 +116,7 @@ const {
   description,
 } = await getProviderApplication(
   managementCredentials,
-  "a3e64872-6326-4813-948d-db8d8fc81bc8"
+  "a3e64872-6326-4813-948d-db8d8fc81bc8",
 );
 ```
 
@@ -129,7 +129,7 @@ import { getIdentities } from "@fewlines/connect-management";
 
 const identities = await getIdentities(
   managementCredentials,
-  "d96ee314-31b2-4e19-88b7-63734b90d1d4"
+  "d96ee314-31b2-4e19-88b7-63734b90d1d4",
 );
 ```
 
@@ -147,7 +147,7 @@ const input = {
 
 const { id, primary, status, type, value } = await getIdentity(
   managementCredentials,
-  input
+  input,
 );
 ```
 
@@ -170,7 +170,7 @@ import { getUserIdFromIdentityValue } from "@fewlines/connect-management";
 
 const userID = await getUserIdFromIdentityValue(
   managementCredentials,
-  "foo@fewlines.co"
+  "foo@fewlines.co",
 );
 ```
 
@@ -183,7 +183,7 @@ import { isUserPasswordSet } from "@fewlines/connect-management";
 
 const isPasswordSet = await isUserPasswordSet(
   managementCredentials,
-  "16071981-1536-4eb2-a33e-892dc84c14a4"
+  "16071981-1536-4eb2-a33e-892dc84c14a4",
 );
 ```
 
@@ -219,7 +219,7 @@ const input = {
 
 const isPasswordSet = await createOrUpdatePassword(
   managementCredentials,
-  input
+  input,
 );
 ```
 
@@ -278,7 +278,7 @@ import { deleteUser } from "@fewlines/connect-management";
 
 const deleteStatus = await deleteUser(
   managementCredentials,
-  "f084749a-2e90-4891-a26f-65e08c4f4e69"
+  "f084749a-2e90-4891-a26f-65e08c4f4e69",
 );
 ```
 
@@ -292,7 +292,7 @@ import { markIdentityAsPrimary } from "@fewlines/connect-management";
 
 const newPrimaryIdentity = await markIdentityAsPrimary(
   managementCredentials,
-  "504c741c-f9dd-425c-912a-03fe051b0e6e"
+  "504c741c-f9dd-425c-912a-03fe051b0e6e",
 );
 ```
 
@@ -311,7 +311,7 @@ const input = {
 
 const isIdentityRemove = await removeIdentityFromUser(
   managementCredentials,
-  input
+  input,
 );
 ```
 
@@ -433,7 +433,7 @@ await updateIdentity(
   eventId,
   validationCode,
   identityValue,
-  identityToUpdateId
+  identityToUpdateId,
 );
 ```
 

--- a/management/package.json
+++ b/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-management",
-  "version": "0.0.0-experimental-7cb23f2",
+  "version": "0.4.1",
   "author": "Fewlines",
   "description": "Management flow for the Connect JS SDK",
   "license": "MIT",

--- a/management/package.json
+++ b/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-management",
-  "version": "0.0.0-experimental-84d1291",
+  "version": "0.0.0-experimental-7cb23f2",
   "author": "Fewlines",
   "description": "Management flow for the Connect JS SDK",
   "license": "MIT",

--- a/management/package.json
+++ b/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-management",
-  "version": "0.4.0",
+  "version": "0.0.0-experimental-84d1291",
   "author": "Fewlines",
   "description": "Management flow for the Connect JS SDK",
   "license": "MIT",

--- a/management/src/commands/update-identity.ts
+++ b/management/src/commands/update-identity.ts
@@ -38,7 +38,7 @@ async function updateIdentity(
 
   const { id: identityId } = await addIdentityToUser(managementCredentials, {
     userId,
-    identityType: identityToUpdate.type,
+    identityType: getIdentityType(identityToUpdate.type),
     identityValue,
   });
 
@@ -60,12 +60,12 @@ async function updateIdentity(
 
   await removeIdentityFromUser(managementCredentials, {
     userId,
-    identityType: identityToUpdate.type,
+    identityType: getIdentityType(identityToUpdate.type),
     identityValue: identityToUpdate.value,
   }).catch(async (error) => {
     const identity = {
       userId,
-      identityType: identityToUpdate.type,
+      identityType: getIdentityType(identityToUpdate.type),
       identityValue: identityToUpdate.value,
     };
 

--- a/management/src/commands/update-identity.ts
+++ b/management/src/commands/update-identity.ts
@@ -2,6 +2,7 @@ import { IdentityNotFoundError, InvalidValidationCodeError } from "../errors";
 import { checkVerificationCode } from "../queries/check-verification-code";
 import { getIdentity } from "../queries/get-identity";
 import { ManagementCredentials } from "../types";
+import { getIdentityType } from "../utils/get-identity-type";
 import { addIdentityToUser } from "./add-identity-to-user";
 import { markIdentityAsPrimary } from "./mark-identity-as-primary";
 import { removeIdentityFromUser } from "./remove-identity-from-user";
@@ -46,7 +47,7 @@ async function updateIdentity(
       async (error) => {
         const identity = {
           userId,
-          identityType: identityToUpdate.type,
+          identityType: getIdentityType(identityToUpdate.type),
           identityValue,
         };
 

--- a/management/src/errors.ts
+++ b/management/src/errors.ts
@@ -58,11 +58,8 @@ class IdentityNotFoundError extends Error {
 }
 
 class UnhandledIdentityType extends Error {
-  readonly message: string;
-
   constructor(message: string) {
-    super();
-    this.message = message;
+    super(message);
   }
 }
 

--- a/management/src/errors.ts
+++ b/management/src/errors.ts
@@ -57,6 +57,15 @@ class IdentityNotFoundError extends Error {
   readonly message = "Identity Not Found";
 }
 
+class UnhandledIdentityType extends Error {
+  readonly message: string;
+
+  constructor(message: string) {
+    super();
+    this.message = message;
+  }
+}
+
 export {
   ConnectUnreachableError,
   GraphqlError,
@@ -67,4 +76,5 @@ export {
   IdentityValueCantBeBlankError,
   InvalidValidationCodeError,
   IdentityNotFoundError,
+  UnhandledIdentityType,
 };

--- a/management/src/utils/get-identity-type.ts
+++ b/management/src/utils/get-identity-type.ts
@@ -1,0 +1,41 @@
+import { UnhandledIdentityType } from "../errors";
+import { IdentityTypes } from "../types";
+
+function getIdentityType(type: string): IdentityTypes {
+  switch (type.toUpperCase()) {
+    case "EMAIL":
+      return IdentityTypes.EMAIL;
+    case "PHONE":
+      return IdentityTypes.PHONE;
+    case "APPLE":
+      return IdentityTypes.APPLE;
+    case "FACEBOOK":
+      return IdentityTypes.FACEBOOK;
+    case "GITHUB":
+      return IdentityTypes.GITHUB;
+    case "GOOGLE":
+      return IdentityTypes.GOOGLE;
+    case "KAKAO_TALK":
+      return IdentityTypes.KAKAO_TALK;
+    case "LINE":
+      return IdentityTypes.LINE;
+    case "NAVER":
+      return IdentityTypes.NAVER;
+    case "PAYPAL":
+      return IdentityTypes.PAYPAL;
+    case "STRAVA":
+      return IdentityTypes.STRAVA;
+    case "VKONTAKTE":
+      return IdentityTypes.VKONTAKTE;
+    case "MICROSOFT":
+      return IdentityTypes.MICROSOFT;
+    case "PROVIDER":
+      return IdentityTypes.PROVIDER;
+    case "DECATHLON":
+      return IdentityTypes.DECATHLON;
+    default:
+      throw new UnhandledIdentityType(`Can't deal with identity type ${type}`);
+  }
+}
+
+export { getIdentityType };


### PR DESCRIPTION
This PR aims at fixing the IdentityType type for the GraphQL document. We had the following error in Connect.Account
```sh
Error GraphqlErrors: Argument "input" has invalid value {userId: $userId, type: $type, value: $value, validated: true}.
In field "type": Expected type "IdentityTypes!", found $type.
```

I migrated the function `getIdentityType` from Connect.Account, but I'm not sure it should be exported by this package. @Fenntasy I would like your input on this one. Is is time to get ride of the enum?