### PR TITLE
Added the `Error` suffix to errors names + bump of deps

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] - 2021-02-24
+
+### Changes
+
+- 💥 Added the `Error` suffix to errors names.
+
+### Bumps
+
+```sh
+  eslint-config-prettier            dev     ~2mo     7.1.0  →     8.1.0   ⩽1d
+  @fewlines/eslint-config           dev     ~7mo     3.0.0  →     3.1.2   ~2d
+  @typescript-eslint/eslint-plugin  dev     ~2mo    4.11.0  →    4.15.2   ~3d
+  @typescript-eslint/parser         dev     ~2mo    4.11.0  →    4.15.2   ~3d
+  eslint                            dev     ~2mo    7.16.0  →    7.20.0  ~13d
+  ts-jest                           dev     ~4mo    26.4.4  →    26.5.2   ~2d
+  typescript                        dev     ~3mo     4.1.3  →     4.2.2   ~2d
+  @types/jest                       dev     ~3mo   26.0.19  →   26.0.20  ~2mo
+  @types/node                       dev     ~2mo  14.14.14  →  14.14.31   ~6d
+  @types/node-fetch                 dev    ~10mo     2.5.7  →     2.5.8  ~1mo
+  eslint-plugin-prettier            dev     ~2mo     3.3.0  →     3.3.1  ~2mo
+```
+
 ## [0.3.0] - 2021-02-15
 
 - Added retry of JWT verification to handle public key rotation.

--- a/client/README.md
+++ b/client/README.md
@@ -67,7 +67,7 @@ Returns a list containing the `access_token`, `refresh_token`, and `id_token` if
 
 ```typescript
 const tokens = await oauthClient.getTokensFromAuthorizationCode(
-  "authorization_code"
+  "authorization_code",
 );
 ```
 
@@ -101,7 +101,7 @@ const decrypted = oauthClient.decryptJWE<string>(JWE, privateKey, true);
 const decrypted = oauthClient.decryptJWE<{ [key: string]: string }>(
   JWE,
   privateKey,
-  false
+  false,
 );
 ```
 
@@ -115,7 +115,7 @@ Returns a refreshed `access_token` along with a new `refresh_token`.
 
 ```typescript
 const { refresh_token, access_token } = await oauthClient.refreshTokens(
-  "refresh_token"
+  "refresh_token",
 );
 ```
 

--- a/client/index.ts
+++ b/client/index.ts
@@ -3,12 +3,12 @@ import nodeFetch from "node-fetch";
 import jose from "node-jose";
 
 import {
-  MissingJWKSURI,
-  InvalidKeyIDRS256,
-  MissingKeyIDHS256,
-  AlgoNotSupported,
-  InvalidAudience,
-  ScopesNotSupported,
+  MissingJWKSURIError,
+  InvalidKeyIDRS256Error,
+  MissingKeyIDHS256Error,
+  AlgoNotSupportedError,
+  InvalidAudienceError,
+  ScopesNotSupportedError,
 } from "./src/errors";
 import {
   OpenIDConfiguration,
@@ -85,7 +85,7 @@ class OAuth2Client {
     const openIDConfiguration = await this.getOpenIDConfiguration();
 
     if (!openIDConfiguration.jwks_uri) {
-      throw new MissingJWKSURI("Missing JWKS URI for RS256 encoded JWT");
+      throw new MissingJWKSURIError("Missing JWKS URI for RS256 encoded JWT");
     }
 
     return await this.fetch(openIDConfiguration.jwks_uri)
@@ -109,7 +109,9 @@ class OAuth2Client {
       const publicKey = rsaPublicKeyToPEM(n, e);
       return publicKey;
     } else {
-      throw new InvalidKeyIDRS256("Invalid key ID (kid) for RS256 encoded JWT");
+      throw new InvalidKeyIDRS256Error(
+        "Invalid key ID (kid) for RS256 encoded JWT",
+      );
     }
   }
 
@@ -159,7 +161,7 @@ class OAuth2Client {
     );
 
     if (!areScopesSupported) {
-      throw new ScopesNotSupported("Scopes are not supported");
+      throw new ScopesNotSupportedError("Scopes are not supported");
     }
 
     const authorizeURL = new URL(authorization_endpoint);
@@ -230,7 +232,7 @@ class OAuth2Client {
       (typeof aud === "string" && aud !== this.audience) ||
       (Array.isArray(aud) && !aud.includes(this.audience))
     ) {
-      throw new InvalidAudience("Invalid audience");
+      throw new InvalidAudienceError("Invalid audience");
     }
 
     if (alg === "HS256" && algo === "HS256") {
@@ -241,12 +243,12 @@ class OAuth2Client {
 
         return await this.verifyRS256(accessToken, publicKey);
       } else {
-        throw new MissingKeyIDHS256(
+        throw new MissingKeyIDHS256Error(
           "Missing key ID (kid) for RS256 encoded JWT",
         );
       }
     } else {
-      throw new AlgoNotSupported("Encoding algo not supported");
+      throw new AlgoNotSupportedError("Encoding algo not supported");
     }
   }
 
@@ -298,12 +300,12 @@ export {
   OAuth2ClientConstructor,
   decodeJWTPart,
   rsaPublicKeyToPEM,
-  MissingJWKSURI,
-  InvalidKeyIDRS256,
-  MissingKeyIDHS256,
-  AlgoNotSupported,
-  InvalidAudience,
-  ScopesNotSupported,
+  MissingJWKSURIError,
+  InvalidKeyIDRS256Error,
+  MissingKeyIDHS256Error,
+  AlgoNotSupportedError,
+  InvalidAudienceError,
+  ScopesNotSupportedError,
   OAuth2Tokens,
   JWTPayload,
   CustomPayload,

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-client",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "Fewlines",
   "description": "OAuth2 Client for the Connect JS SDK",
   "license": "MIT",
@@ -27,24 +27,24 @@
     "node-jose": "2.0.0"
   },
   "devDependencies": {
-    "@fewlines/eslint-config": "3.0.0",
-    "@types/jest": "26.0.19",
+    "@fewlines/eslint-config": "3.1.2",
+    "@types/jest": "26.0.20",
     "@types/jsonwebtoken": "8.5.0",
-    "@types/node": "14.14.14",
-    "@types/node-fetch": "2.5.7",
+    "@types/node": "14.14.31",
+    "@types/node-fetch": "2.5.8",
     "@types/node-jose": "1.1.5",
-    "@typescript-eslint/eslint-plugin": "4.11.0",
-    "@typescript-eslint/parser": "4.11.0",
-    "eslint": "7.16.0",
-    "eslint-config-prettier": "7.1.0",
+    "@typescript-eslint/eslint-plugin": "4.15.2",
+    "@typescript-eslint/parser": "4.15.2",
+    "eslint": "7.20.0",
+    "eslint-config-prettier": "8.1.0",
     "eslint-plugin-import": "2.22.1",
-    "eslint-plugin-prettier": "3.3.0",
+    "eslint-plugin-prettier": "3.3.1",
     "jest": "26.6.3",
     "jest-fetch-mock": "3.0.3",
     "prettier": "2.2.1",
-    "ts-jest": "26.4.4",
+    "ts-jest": "26.5.2",
     "ts-node": "9.1.1",
-    "typescript": "4.1.3"
+    "typescript": "4.2.2"
   },
   "eslintConfig": {
     "extends": [

--- a/client/src/errors.ts
+++ b/client/src/errors.ts
@@ -1,11 +1,20 @@
-export class MissingJWKSURI extends Error {}
+class MissingJWKSURIError extends Error {}
 
-export class InvalidKeyIDRS256 extends Error {}
+class InvalidKeyIDRS256Error extends Error {}
 
-export class MissingKeyIDHS256 extends Error {}
+class MissingKeyIDHS256Error extends Error {}
 
-export class AlgoNotSupported extends Error {}
+class AlgoNotSupportedError extends Error {}
 
-export class InvalidAudience extends Error {}
+class InvalidAudienceError extends Error {}
 
-export class ScopesNotSupported extends Error {}
+class ScopesNotSupportedError extends Error {}
+
+export {
+  MissingJWKSURIError,
+  InvalidKeyIDRS256Error,
+  MissingKeyIDHS256Error,
+  AlgoNotSupportedError,
+  InvalidAudienceError,
+  ScopesNotSupportedError,
+};

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,4 +1,4 @@
-export type OpenIDConfiguration = {
+type OpenIDConfiguration = {
   userinfo_signing_alg_values_supported: string[];
   userinfo_endpoint: string;
   token_endpoint_auth_signing_alg_values_supported: ("HS256" | "RS256")[];
@@ -18,7 +18,7 @@ export type OpenIDConfiguration = {
   authorization_endpoint: string;
 };
 
-export type OAuth2ClientConstructor = {
+type OAuth2ClientConstructor = {
   openIDConfigurationURL: string;
   clientID: string;
   clientSecret: string;
@@ -29,7 +29,7 @@ export type OAuth2ClientConstructor = {
   openIDConfiguration?: OpenIDConfiguration;
 };
 
-export type JWKSDT = {
+type JWKSDT = {
   keys: {
     use: string;
     n: string;
@@ -40,13 +40,13 @@ export type JWKSDT = {
   }[];
 };
 
-export type OAuth2Tokens = {
+type OAuth2Tokens = {
   refresh_token: string;
   access_token: string;
   id_token?: string;
 };
 
-export type JWTPayload = {
+type JWTPayload = {
   aud: string | string[];
   exp: number;
   iss: string;
@@ -54,9 +54,19 @@ export type JWTPayload = {
   sub: string;
 };
 
-export type RefreshTokenResponse = {
+type RefreshTokenResponse = {
   refresh_token: string;
   access_token: string;
 };
 
-export type CustomPayload = Record<string, unknown>;
+type CustomPayload = Record<string, unknown>;
+
+export type {
+  OpenIDConfiguration,
+  OAuth2ClientConstructor,
+  JWKSDT,
+  OAuth2Tokens,
+  JWTPayload,
+  RefreshTokenResponse,
+  CustomPayload,
+};

--- a/client/src/utils/decodeJWTPart.ts
+++ b/client/src/utils/decodeJWTPart.ts
@@ -1,4 +1,4 @@
-export function decodeJWTPart<T = unknown>(JWTPart: string): T {
+function decodeJWTPart<T = unknown>(JWTPart: string): T {
   const base64 = JWTPart.replace(/-/g, "+").replace(/_/g, "/");
   const buff = Buffer.from(base64, "base64");
   const decoded = buff.toString("ascii");
@@ -14,3 +14,5 @@ export function decodeJWTPart<T = unknown>(JWTPart: string): T {
 
   return JSON.parse(jsonPayload) as T;
 }
+
+export { decodeJWTPart };

--- a/client/src/utils/generateJWS.ts
+++ b/client/src/utils/generateJWS.ts
@@ -7,7 +7,7 @@ import {
   defaultSecret,
 } from "./defaultObjects";
 
-export function generateHS256JWS(
+function generateHS256JWS(
   customPayload?: CustomPayload,
   secret?: string,
 ): string {
@@ -20,7 +20,7 @@ export function generateHS256JWS(
   );
 }
 
-export function generateRS256JWS(
+function generateRS256JWS(
   customPayload?: CustomPayload,
   privateKey?: string,
 ): string {
@@ -32,3 +32,5 @@ export function generateRS256JWS(
     },
   );
 }
+
+export { generateHS256JWS, generateRS256JWS };

--- a/client/src/utils/rsaPublicKeyToPEM.ts
+++ b/client/src/utils/rsaPublicKeyToPEM.ts
@@ -29,10 +29,7 @@ function encodeLengthHex(n: number): string {
   return toHex(lengthOfLengthByte) + nHex;
 }
 
-export function rsaPublicKeyToPEM(
-  modulusB64: string,
-  exponentB64: string,
-): string {
+function rsaPublicKeyToPEM(modulusB64: string, exponentB64: string): string {
   const modulus = Buffer.from(modulusB64, "base64");
   const exponent = Buffer.from(exponentB64, "base64");
   const modulusHex = prepadSigned(modulus.toString("hex"));
@@ -61,3 +58,5 @@ export function rsaPublicKeyToPEM(
   pem += "\n-----END RSA PUBLIC KEY-----\n";
   return pem;
 }
+
+export { rsaPublicKeyToPEM };

--- a/client/tests/index.test.ts
+++ b/client/tests/index.test.ts
@@ -5,11 +5,11 @@ import jwt, { JsonWebTokenError } from "jsonwebtoken";
 import jose from "node-jose";
 
 import OAuth2Client, {
-  InvalidAudience,
-  InvalidKeyIDRS256,
-  MissingKeyIDHS256,
-  AlgoNotSupported,
-  ScopesNotSupported,
+  InvalidAudienceError,
+  InvalidKeyIDRS256Error,
+  MissingKeyIDHS256Error,
+  AlgoNotSupportedError,
+  ScopesNotSupportedError,
   defaultSecret,
   OAuth2ClientConstructor,
   defaultPayload,
@@ -124,7 +124,7 @@ describe("OAuth2Client", () => {
       });
 
       await oauthClient.getAuthorizationURL().catch((error) => {
-        expect(error).toBeInstanceOf(ScopesNotSupported);
+        expect(error).toBeInstanceOf(ScopesNotSupportedError);
         expect(error.message).toBe("Scopes are not supported");
       });
     });
@@ -200,7 +200,7 @@ describe("OAuth2Client", () => {
       await oauthClient
         .verifyJWT(wrongAudienceHS256JWT, "HS256")
         .catch((error) => {
-          expect(error).toBeInstanceOf(InvalidAudience);
+          expect(error).toBeInstanceOf(InvalidAudienceError);
           expect(error.message).toBe("Invalid audience");
         });
     });
@@ -313,7 +313,7 @@ describe("OAuth2Client", () => {
           .once(JSON.stringify(wrongKidJWKS));
 
         await oauthClient.verifyJWT(RS256JWT, "RS256").catch((error) => {
-          expect(error).toBeInstanceOf(InvalidKeyIDRS256);
+          expect(error).toBeInstanceOf(InvalidKeyIDRS256Error);
           expect(error.message).toBe(
             "Invalid key ID (kid) for RS256 encoded JWT",
           );
@@ -391,7 +391,7 @@ describe("OAuth2Client", () => {
         );
 
         await oauthClient.verifyJWT(missingKidJWT, "RS256").catch((error) => {
-          expect(error).toBeInstanceOf(MissingKeyIDHS256);
+          expect(error).toBeInstanceOf(MissingKeyIDHS256Error);
           expect(error.message).toBe(
             "Missing key ID (kid) for RS256 encoded JWT",
           );
@@ -410,7 +410,7 @@ describe("OAuth2Client", () => {
         });
 
         await oauthClient.verifyJWT(noAlgoJWT, "RS256").catch((error) => {
-          expect(error).toBeInstanceOf(AlgoNotSupported);
+          expect(error).toBeInstanceOf(AlgoNotSupportedError);
           expect(error.message).toBe("Encoding algo not supported");
         });
       });

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.11":
+"@babel/code-frame@7.12.11", "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
   integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
@@ -278,10 +278,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@eslint/eslintrc@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.2.2.tgz#d01fc791e2fc33e88a29d6f3dc7e93d0cd784b76"
-  integrity sha512-EfB5OHNYp1F4px/LI/FEnGylop7nOqkQ1LRzCM0KccA2U8tvV8w01KBv37LbO7nW4H+YhKyo2LcJhRwjjV17QQ==
+"@eslint/eslintrc@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.3.0.tgz#d736d6963d7003b6514e6324bec9c602ac340318"
+  integrity sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==
   dependencies:
     ajv "^6.12.4"
     debug "^4.1.1"
@@ -290,14 +290,14 @@
     ignore "^4.0.6"
     import-fresh "^3.2.1"
     js-yaml "^3.13.1"
-    lodash "^4.17.19"
+    lodash "^4.17.20"
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fewlines/eslint-config@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@fewlines/eslint-config/-/eslint-config-3.0.0.tgz#2d8c2be46b8bfec8222942b8ccc999d6d6d714f3"
-  integrity sha512-5J9UukKUA4phA1zAgZJIcVLv8Ps5kpNGAD3jtPqe/Ee2HhLN6AZTlThmgUIqIvm/0ZpDI7d/mrBPNcnt0nOuYA==
+"@fewlines/eslint-config@3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@fewlines/eslint-config/-/eslint-config-3.1.2.tgz#14e9bbc8c6027a118e1fc4135827b2f028dfc87f"
+  integrity sha512-JDSQ4FR4MDf6KaOSLinP+9S212BFRiYKo2GTk9OfjzJg+5CXajIilJKfpehIiCnzi2Ptcj7+Xr88njOspPid2Q==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -580,15 +580,7 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@26.0.19":
-  version "26.0.19"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.19.tgz#e6fa1e3def5842ec85045bd5210e9bb8289de790"
-  integrity sha512-jqHoirTG61fee6v6rwbnEuKhpSKih0tuhqeFbCmMmErhtu3BYlOZaXWjffgOstMM4S/3iQD31lI5bGLTrs97yQ==
-  dependencies:
-    jest-diff "^26.0.0"
-    pretty-format "^26.0.0"
-
-"@types/jest@26.x":
+"@types/jest@26.0.20", "@types/jest@26.x":
   version "26.0.20"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.20.tgz#cd2f2702ecf69e86b586e1f5223a60e454056307"
   integrity sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==
@@ -613,10 +605,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node-fetch@2.5.7":
-  version "2.5.7"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.7.tgz#20a2afffa882ab04d44ca786449a276f9f6bbf3c"
-  integrity sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==
+"@types/node-fetch@2.5.8":
+  version "2.5.8"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.8.tgz#e199c835d234c7eb0846f6618012e558544ee2fb"
+  integrity sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==
   dependencies:
     "@types/node" "*"
     form-data "^3.0.0"
@@ -633,10 +625,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.20.tgz#f7974863edd21d1f8a494a73e8e2b3658615c340"
   integrity sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A==
 
-"@types/node@14.14.14":
-  version "14.14.14"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.14.tgz#f7fd5f3cc8521301119f63910f0fb965c7d761ae"
-  integrity sha512-UHnOPWVWV1z+VV8k6L1HhG7UbGBgIdghqF3l9Ny9ApPghbjICXkUJSd/b9gOgQfjM1r+37cipdw/HJ3F6ICEnQ==
+"@types/node@14.14.31":
+  version "14.14.31"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.31.tgz#72286bd33d137aa0d152d47ec7c1762563d34055"
+  integrity sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -665,74 +657,74 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.11.0.tgz#bc6c1e4175c0cf42083da4314f7931ad12f731cc"
-  integrity sha512-x4arJMXBxyD6aBXLm3W7mSDZRiABzy+2PCLJbL7OPqlp53VXhaA1HKK7R2rTee5OlRhnUgnp8lZyVIqjnyPT6g==
+"@typescript-eslint/eslint-plugin@4.15.2":
+  version "4.15.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.15.2.tgz#981b26b4076c62a5a55873fbef3fe98f83360c61"
+  integrity sha512-uiQQeu9tWl3f1+oK0yoAv9lt/KXO24iafxgQTkIYO/kitruILGx3uH+QtIAHqxFV+yIsdnJH+alel9KuE3J15Q==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.11.0"
-    "@typescript-eslint/scope-manager" "4.11.0"
+    "@typescript-eslint/experimental-utils" "4.15.2"
+    "@typescript-eslint/scope-manager" "4.15.2"
     debug "^4.1.1"
     functional-red-black-tree "^1.0.1"
+    lodash "^4.17.15"
     regexpp "^3.0.0"
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.11.0.tgz#d1a47cc6cfe1c080ce4ead79267574b9881a1565"
-  integrity sha512-1VC6mSbYwl1FguKt8OgPs8xxaJgtqFpjY/UzUYDBKq4pfQ5lBvN2WVeqYkzf7evW42axUHYl2jm9tNyFsb8oLg==
+"@typescript-eslint/experimental-utils@4.15.2":
+  version "4.15.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.15.2.tgz#5efd12355bd5b535e1831282e6cf465b9a71cf36"
+  integrity sha512-Fxoshw8+R5X3/Vmqwsjc8nRO/7iTysRtDqx6rlfLZ7HbT8TZhPeQqbPjTyk2RheH3L8afumecTQnUc9EeXxohQ==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/scope-manager" "4.11.0"
-    "@typescript-eslint/types" "4.11.0"
-    "@typescript-eslint/typescript-estree" "4.11.0"
+    "@typescript-eslint/scope-manager" "4.15.2"
+    "@typescript-eslint/types" "4.15.2"
+    "@typescript-eslint/typescript-estree" "4.15.2"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.11.0.tgz#1dd3d7e42708c10ce9f3aa64c63c0ab99868b4e2"
-  integrity sha512-NBTtKCC7ZtuxEV5CrHUO4Pg2s784pvavc3cnz6V+oJvVbK4tH9135f/RBP6eUA2KHiFKAollSrgSctQGmHbqJQ==
+"@typescript-eslint/parser@4.15.2":
+  version "4.15.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.15.2.tgz#c804474321ef76a3955aec03664808f0d6e7872e"
+  integrity sha512-SHeF8xbsC6z2FKXsaTb1tBCf0QZsjJ94H6Bo51Y1aVEZ4XAefaw5ZAilMoDPlGghe+qtq7XdTiDlGfVTOmvA+Q==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.11.0"
-    "@typescript-eslint/types" "4.11.0"
-    "@typescript-eslint/typescript-estree" "4.11.0"
+    "@typescript-eslint/scope-manager" "4.15.2"
+    "@typescript-eslint/types" "4.15.2"
+    "@typescript-eslint/typescript-estree" "4.15.2"
     debug "^4.1.1"
 
-"@typescript-eslint/scope-manager@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.11.0.tgz#2d906537db8a3a946721699e4fc0833810490254"
-  integrity sha512-6VSTm/4vC2dHM3ySDW9Kl48en+yLNfVV6LECU8jodBHQOhO8adAVizaZ1fV0QGZnLQjQ/y0aBj5/KXPp2hBTjA==
+"@typescript-eslint/scope-manager@4.15.2":
+  version "4.15.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.15.2.tgz#5725bda656995960ae1d004bfd1cd70320f37f4f"
+  integrity sha512-Zm0tf/MSKuX6aeJmuXexgdVyxT9/oJJhaCkijv0DvJVT3ui4zY6XYd6iwIo/8GEZGy43cd7w1rFMiCLHbRzAPQ==
   dependencies:
-    "@typescript-eslint/types" "4.11.0"
-    "@typescript-eslint/visitor-keys" "4.11.0"
+    "@typescript-eslint/types" "4.15.2"
+    "@typescript-eslint/visitor-keys" "4.15.2"
 
-"@typescript-eslint/types@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.11.0.tgz#86cf95e7eac4ccfd183f9fcf1480cece7caf4ca4"
-  integrity sha512-XXOdt/NPX++txOQHM1kUMgJUS43KSlXGdR/aDyEwuAEETwuPt02Nc7v+s57PzuSqMbNLclblQdv3YcWOdXhQ7g==
+"@typescript-eslint/types@4.15.2":
+  version "4.15.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.15.2.tgz#04acf3a2dc8001a88985291744241e732ef22c60"
+  integrity sha512-r7lW7HFkAarfUylJ2tKndyO9njwSyoy6cpfDKWPX6/ctZA+QyaYscAHXVAfJqtnY6aaTwDYrOhp+ginlbc7HfQ==
 
-"@typescript-eslint/typescript-estree@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.11.0.tgz#1144d145841e5987d61c4c845442a24b24165a4b"
-  integrity sha512-eA6sT5dE5RHAFhtcC+b5WDlUIGwnO9b0yrfGa1mIOIAjqwSQCpXbLiFmKTdRbQN/xH2EZkGqqLDrKUuYOZ0+Hg==
+"@typescript-eslint/typescript-estree@4.15.2":
+  version "4.15.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.15.2.tgz#c2f7a1e94f3428d229d5ecff3ead6581ee9b62fa"
+  integrity sha512-cGR8C2g5SPtHTQvAymEODeqx90pJHadWsgTtx6GbnTWKqsg7yp6Eaya9nFzUd4KrKhxdYTTFBiYeTPQaz/l8bw==
   dependencies:
-    "@typescript-eslint/types" "4.11.0"
-    "@typescript-eslint/visitor-keys" "4.11.0"
+    "@typescript-eslint/types" "4.15.2"
+    "@typescript-eslint/visitor-keys" "4.15.2"
     debug "^4.1.1"
     globby "^11.0.1"
     is-glob "^4.0.1"
-    lodash "^4.17.15"
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/visitor-keys@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.11.0.tgz#906669a50f06aa744378bb84c7d5c4fdbc5b7d51"
-  integrity sha512-tRYKyY0i7cMk6v4UIOCjl1LhuepC/pc6adQqJk4Is3YcC6k46HvsV9Wl7vQoLbm9qADgeujiT7KdLrylvFIQ+A==
+"@typescript-eslint/visitor-keys@4.15.2":
+  version "4.15.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.15.2.tgz#3d1c7979ce75bf6acf9691109bd0d6b5706192b9"
+  integrity sha512-TME1VgSb7wTwgENN5KVj4Nqg25hP8DisXxNBojM4Nn31rYaNDIocNm5cmjOFfh42n7NVERxWrDFoETO/76ePyg==
   dependencies:
-    "@typescript-eslint/types" "4.11.0"
+    "@typescript-eslint/types" "4.15.2"
     eslint-visitor-keys "^2.0.0"
 
 abab@^2.0.3:
@@ -1557,10 +1549,10 @@ escodegen@^1.14.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-prettier@7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-7.1.0.tgz#5402eb559aa94b894effd6bddfa0b1ca051c858f"
-  integrity sha512-9sm5/PxaFG7qNJvJzTROMM1Bk1ozXVTKI0buKOyb0Bsr1hrwi0H/TzxF/COtf1uxikIK8SwhX7K6zg78jAzbeA==
+eslint-config-prettier@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.1.0.tgz#4ef1eaf97afe5176e6a75ddfb57c335121abc5a6"
+  integrity sha512-oKMhGv3ihGbCIimCAjqkdzx2Q+jthoqnXSP+d86M9tptwugycmTFdVR4IpLgq2c4SHifbwO90z2fQ8/Aio73yw==
 
 eslint-import-resolver-node@^0.3.4:
   version "0.3.4"
@@ -1597,10 +1589,10 @@ eslint-plugin-import@2.22.1:
     resolve "^1.17.0"
     tsconfig-paths "^3.9.0"
 
-eslint-plugin-prettier@3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.0.tgz#61e295349a65688ffac0b7808ef0a8244bdd8d40"
-  integrity sha512-tMTwO8iUWlSRZIwS9k7/E4vrTsfvsrcM5p1eftyuqWH25nKsz/o6/54I7jwQ/3zobISyC7wMy9ZsFwgTxOcOpQ==
+eslint-plugin-prettier@3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.1.tgz#7079cfa2497078905011e6f82e8dd8453d1371b7"
+  integrity sha512-Rq3jkcFY8RYeQLgk2cCwuc0P7SEFwDravPhsJZOQ5N4YI4DSg50NyqJ/9gdZHzQlHf8MvafSesbNJCcP/FF6pQ==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
@@ -1629,13 +1621,13 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
-eslint@7.16.0:
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.16.0.tgz#a761605bf9a7b32d24bb7cde59aeb0fd76f06092"
-  integrity sha512-iVWPS785RuDA4dWuhhgXTNrGxHHK3a8HLSMBgbbU59ruJDubUraXN8N5rn7kb8tG6sjg74eE0RA3YWT51eusEw==
+eslint@7.20.0:
+  version "7.20.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.20.0.tgz#db07c4ca4eda2e2316e7aa57ac7fc91ec550bdc7"
+  integrity sha512-qGi0CTcOGP2OtCQBgWZlQjcTuP0XkIpYFj25XtRTQSHC+umNnp7UMshr2G8SLsRFYDdAPFeHOsiteadmMH02Yw==
   dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@eslint/eslintrc" "^0.2.2"
+    "@babel/code-frame" "7.12.11"
+    "@eslint/eslintrc" "^0.3.0"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
@@ -1646,7 +1638,7 @@ eslint@7.16.0:
     eslint-utils "^2.1.0"
     eslint-visitor-keys "^2.0.0"
     espree "^7.3.1"
-    esquery "^1.2.0"
+    esquery "^1.4.0"
     esutils "^2.0.2"
     file-entry-cache "^6.0.0"
     functional-red-black-tree "^1.0.1"
@@ -1659,7 +1651,7 @@ eslint@7.16.0:
     js-yaml "^3.13.1"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.4.1"
-    lodash "^4.17.19"
+    lodash "^4.17.20"
     minimatch "^3.0.4"
     natural-compare "^1.4.0"
     optionator "^0.9.1"
@@ -1686,10 +1678,10 @@ esprima@^4.0.0, esprima@^4.0.1:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.3.1.tgz#b78b5828aa8e214e29fb74c4d5b752e1c033da57"
-  integrity sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==
+esquery@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
+  integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
   dependencies:
     estraverse "^5.1.0"
 
@@ -3131,11 +3123,6 @@ lodash.isstring@^4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
   integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
 
-lodash.memoize@4.x:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
-  integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
-
 lodash.once@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
@@ -3145,6 +3132,11 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
+
+lodash@4.x:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
   version "4.17.20"
@@ -4396,10 +4388,10 @@ tr46@^2.0.2:
   dependencies:
     punycode "^2.1.1"
 
-ts-jest@26.4.4:
-  version "26.4.4"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.4.4.tgz#61f13fb21ab400853c532270e52cc0ed7e502c49"
-  integrity sha512-3lFWKbLxJm34QxyVNNCgXX1u4o/RV0myvA2y2Bxm46iGIjKlaY0own9gIckbjZJPn+WaJEnfPPJ20HHGpoq4yg==
+ts-jest@26.5.2:
+  version "26.5.2"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.2.tgz#5281d6b44c2f94f71205728a389edc3d7995b0c4"
+  integrity sha512-bwyJ2zJieSugf7RB+o8fgkMeoMVMM2KPDE0UklRLuACxjwJsOrZNo6chrcScmK33YavPSwhARffy8dZx5LJdUQ==
   dependencies:
     "@types/jest" "26.x"
     bs-logger "0.x"
@@ -4407,7 +4399,7 @@ ts-jest@26.4.4:
     fast-json-stable-stringify "2.x"
     jest-util "^26.1.0"
     json5 "2.x"
-    lodash.memoize "4.x"
+    lodash "4.x"
     make-error "1.x"
     mkdirp "1.x"
     semver "7.x"
@@ -4500,10 +4492,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+typescript@4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.2.tgz#1450f020618f872db0ea17317d16d8da8ddb8c4c"
+  integrity sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
This PR is a prep fork for the web errors in Connect.Account, and aims at adding the `Error` suffix to errors for consistency across our repos.

I also bumped the deps, and fixed the exports following the new `eslint-config` rules.