### PR TITLE
Changing createOrUpdatePassword rules error data structure

### DIFF
--- a/management/CHANGELOG.md
+++ b/management/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.1] - 2021-03-03
+
+- Change of error data structure in `createOrUpdatePassword`.
+
 ## [0.5.0] - 2021-03-01
 
 - 💥 `addIdentityToUser` now takes a list of event IDs.

--- a/management/README.md
+++ b/management/README.md
@@ -116,7 +116,7 @@ const {
   description,
 } = await getProviderApplication(
   managementCredentials,
-  "a3e64872-6326-4813-948d-db8d8fc81bc8"
+  "a3e64872-6326-4813-948d-db8d8fc81bc8",
 );
 ```
 
@@ -129,7 +129,7 @@ import { getIdentities } from "@fewlines/connect-management";
 
 const identities = await getIdentities(
   managementCredentials,
-  "d96ee314-31b2-4e19-88b7-63734b90d1d4"
+  "d96ee314-31b2-4e19-88b7-63734b90d1d4",
 );
 ```
 
@@ -147,7 +147,7 @@ const input = {
 
 const { id, primary, status, type, value } = await getIdentity(
   managementCredentials,
-  input
+  input,
 );
 ```
 
@@ -170,7 +170,7 @@ import { getUserIdFromIdentityValue } from "@fewlines/connect-management";
 
 const userID = await getUserIdFromIdentityValue(
   managementCredentials,
-  "foo@fewlines.co"
+  "foo@fewlines.co",
 );
 ```
 
@@ -183,7 +183,7 @@ import { isUserPasswordSet } from "@fewlines/connect-management";
 
 const isPasswordSet = await isUserPasswordSet(
   managementCredentials,
-  "16071981-1536-4eb2-a33e-892dc84c14a4"
+  "16071981-1536-4eb2-a33e-892dc84c14a4",
 );
 ```
 
@@ -222,7 +222,7 @@ const input = {
 
 const isPasswordSet = await createOrUpdatePassword(
   managementCredentials,
-  input
+  input,
 );
 ```
 
@@ -281,7 +281,7 @@ import { deleteUser } from "@fewlines/connect-management";
 
 const deleteStatus = await deleteUser(
   managementCredentials,
-  "f084749a-2e90-4891-a26f-65e08c4f4e69"
+  "f084749a-2e90-4891-a26f-65e08c4f4e69",
 );
 ```
 
@@ -295,7 +295,7 @@ import { markIdentityAsPrimary } from "@fewlines/connect-management";
 
 const newPrimaryIdentity = await markIdentityAsPrimary(
   managementCredentials,
-  "504c741c-f9dd-425c-912a-03fe051b0e6e"
+  "504c741c-f9dd-425c-912a-03fe051b0e6e",
 );
 ```
 
@@ -314,7 +314,7 @@ const input = {
 
 const isIdentityRemove = await removeIdentityFromUser(
   managementCredentials,
-  input
+  input,
 );
 ```
 
@@ -436,7 +436,7 @@ await updateIdentityFromUser(
   eventIds,
   validationCode,
   identityValue,
-  identityToUpdateId
+  identityToUpdateId,
 );
 ```
 

--- a/management/README.md
+++ b/management/README.md
@@ -116,7 +116,7 @@ const {
   description,
 } = await getProviderApplication(
   managementCredentials,
-  "a3e64872-6326-4813-948d-db8d8fc81bc8",
+  "a3e64872-6326-4813-948d-db8d8fc81bc8"
 );
 ```
 
@@ -129,7 +129,7 @@ import { getIdentities } from "@fewlines/connect-management";
 
 const identities = await getIdentities(
   managementCredentials,
-  "d96ee314-31b2-4e19-88b7-63734b90d1d4",
+  "d96ee314-31b2-4e19-88b7-63734b90d1d4"
 );
 ```
 
@@ -147,7 +147,7 @@ const input = {
 
 const { id, primary, status, type, value } = await getIdentity(
   managementCredentials,
-  input,
+  input
 );
 ```
 
@@ -170,7 +170,7 @@ import { getUserIdFromIdentityValue } from "@fewlines/connect-management";
 
 const userID = await getUserIdFromIdentityValue(
   managementCredentials,
-  "foo@fewlines.co",
+  "foo@fewlines.co"
 );
 ```
 
@@ -183,7 +183,7 @@ import { isUserPasswordSet } from "@fewlines/connect-management";
 
 const isPasswordSet = await isUserPasswordSet(
   managementCredentials,
-  "16071981-1536-4eb2-a33e-892dc84c14a4",
+  "16071981-1536-4eb2-a33e-892dc84c14a4"
 );
 ```
 
@@ -222,11 +222,11 @@ const input = {
 
 const isPasswordSet = await createOrUpdatePassword(
   managementCredentials,
-  input,
+  input
 );
 ```
 
-If the `cleartextPassword` input doesn't meet the Provider defined rules, the function will throw a specific error containing the `rules` waited for the password to be valid. The data structure of the `rules` property is dependent of the Provider settings.
+If the `cleartextPassword` input doesn't meet the Provider defined rules, the function will throw a specific error containing the `rules` waited for the password to be valid.
 
 ```ts
 import {
@@ -281,7 +281,7 @@ import { deleteUser } from "@fewlines/connect-management";
 
 const deleteStatus = await deleteUser(
   managementCredentials,
-  "f084749a-2e90-4891-a26f-65e08c4f4e69",
+  "f084749a-2e90-4891-a26f-65e08c4f4e69"
 );
 ```
 
@@ -295,7 +295,7 @@ import { markIdentityAsPrimary } from "@fewlines/connect-management";
 
 const newPrimaryIdentity = await markIdentityAsPrimary(
   managementCredentials,
-  "504c741c-f9dd-425c-912a-03fe051b0e6e",
+  "504c741c-f9dd-425c-912a-03fe051b0e6e"
 );
 ```
 
@@ -314,7 +314,7 @@ const input = {
 
 const isIdentityRemove = await removeIdentityFromUser(
   managementCredentials,
-  input,
+  input
 );
 ```
 
@@ -436,7 +436,7 @@ await updateIdentityFromUser(
   eventIds,
   validationCode,
   identityValue,
-  identityToUpdateId,
+  identityToUpdateId
 );
 ```
 

--- a/management/package.json
+++ b/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-management",
-  "version": "0.5.0",
+  "version": "0.0.0-experimental-8b9fcea",
   "author": "Fewlines",
   "description": "Management flow for the Connect JS SDK",
   "license": "MIT",

--- a/management/package.json
+++ b/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-management",
-  "version": "0.0.0-experimental-8b9fcea",
+  "version": "0.5.1",
   "author": "Fewlines",
   "description": "Management flow for the Connect JS SDK",
   "license": "MIT",

--- a/management/src/commands/create-or-update-password.ts
+++ b/management/src/commands/create-or-update-password.ts
@@ -12,6 +12,7 @@ import {
   ManagementCredentials,
   PasswordRules,
 } from "../types";
+import { flattenDeepObject } from "../utils/flatten-deep-object";
 
 const CREATE_OR_UPDATE_PASSWORD_MUTATION = gql`
   mutation createOrUpdatePassword($cleartextPassword: String!, $userId: ID!) {
@@ -44,9 +45,10 @@ async function createOrUpdatePassword(
     );
 
     if (passwordError) {
-      throw new InvalidPasswordInputError(
+      const formattedPasswordRules = flattenDeepObject(
         (passwordError as GraphQLError & { rules: PasswordRules }).rules,
       );
+      throw new InvalidPasswordInputError(formattedPasswordRules);
     }
 
     throw new GraphqlErrors(errors);

--- a/management/src/errors.ts
+++ b/management/src/errors.ts
@@ -1,8 +1,6 @@
 import { GraphQLError } from "graphql";
 import { FetchError } from "node-fetch";
 
-import { PasswordRules } from "./types";
-
 class GraphqlError extends Error {
   parentError: GraphqlErrors;
 
@@ -24,9 +22,9 @@ class OutputDataNullError extends Error {
 }
 
 class InvalidPasswordInputError extends Error {
-  readonly rules: PasswordRules;
+  readonly rules: Record<string, string>;
 
-  constructor(rules: PasswordRules) {
+  constructor(rules: Record<string, string>) {
     super("Invalid Password Input");
     this.rules = rules;
   }

--- a/management/src/utils/flatten-deep-object.ts
+++ b/management/src/utils/flatten-deep-object.ts
@@ -1,0 +1,28 @@
+function flattenDeepObject(
+  obj: Record<string, unknown>,
+  higherLevelEntry?: string,
+  flattenedObject: Record<string, string> = {},
+): Record<string, string> {
+  const keySeparator = "_";
+
+  for (const [key, value] of Object.entries(obj)) {
+    const entry = higherLevelEntry
+      ? higherLevelEntry.concat(keySeparator, key)
+      : key;
+
+    if (value && typeof value === "object") {
+      flattenDeepObject(
+        value as Record<string, string>,
+        entry,
+        flattenedObject,
+      );
+    } else {
+      if (typeof value !== "undefined") {
+        flattenedObject[entry] = value.toString();
+      }
+    }
+  }
+  return flattenedObject;
+}
+
+export { flattenDeepObject };


### PR DESCRIPTION
This PR changes the data structure of the rules error thrown by `createOrUpdatePassword`. 

It is now a one-level object containing strings. 

A new util function which flattens nested object recursively was added.