### PR TITLE
Renaming 2Fa function

### DIFF
--- a/management/CHANGELOG.md
+++ b/management/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.1] - 2021-03-15
+
+- 💥 Changed the naming of `send2FaVerificationCode` function to `sendTwoFAVerificationCode`.
+
 ## [0.6.0] - 2021-03-09
 
 - New function called `send2FaVerificationCode`, that can be used to send a verification code to a User.

--- a/management/README.md
+++ b/management/README.md
@@ -450,7 +450,7 @@ Here are the expected exception raised in case of a failure:
 - InvalidValidationCodeError
 - UnhandledIdentityType
 
-### send2FaVerificationCode
+### sendTwoFAVerificationCode
 
 Used to send a Verification Code to the User. The function returns an object, composed of:
 
@@ -460,7 +460,7 @@ Used to send a Verification Code to the User. The function returns an object, co
 - The nonce
 
 ```ts
-import { send2FaVerificationCode } from "@fewlines/connect-management";
+import { sendTwoFAVerificationCode } from "@fewlines/connect-management";
 
 const input = {
   callbackUrl: "/",
@@ -479,14 +479,14 @@ const {
   localeCode,
   eventId,
   nonce,
-} = await send2FaVerificationCode(managementCredentials, input);
+} = await sendTwoFAVerificationCode(managementCredentials, input);
 ```
 
 If the Identity `type` isn't a valid one or if the provided Identity is not associated with the `userId`, the function will throw specific errors corresponding to each case.
 
 ```ts
 import {
-  send2FaVerificationCode,
+  sendTwoFAVerificationCode,
   InvalidIdentityTypeError,
   IdentityNotFoundError,
 } from "@fewlines/connect-management";
@@ -509,7 +509,7 @@ try {
     localeCode,
     eventId,
     nonce,
-  } = await send2FaVerificationCode(managementCredentials, input);
+  } = await sendTwoFAVerificationCode(managementCredentials, input);
 } catch (error) {
   if (error instanceof InvalidIdentityTypeError) {
     // ...

--- a/management/package.json
+++ b/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-management",
-  "version": "0.0.0-experimental-2d50777",
+  "version": "0.6.1",
   "author": "Fewlines",
   "description": "Management flow for the Connect JS SDK",
   "license": "MIT",

--- a/management/package.json
+++ b/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-management",
-  "version": "0.6.0",
+  "version": "0.0.0-experimental-2d50777",
   "author": "Fewlines",
   "description": "Management flow for the Connect JS SDK",
   "license": "MIT",

--- a/management/src/commands/index.ts
+++ b/management/src/commands/index.ts
@@ -7,4 +7,4 @@ export * from "./remove-identity-from-user";
 export * from "./send-identity-validation-code";
 export * from "./update-connect-application";
 export * from "./update-identity-from-user";
-export * from "./send-2fa-verification-code";
+export * from "./send-two-fa-verification-code";

--- a/management/src/commands/send-two-fa-verification-code.ts
+++ b/management/src/commands/send-two-fa-verification-code.ts
@@ -10,12 +10,12 @@ import {
 import { fetchManagement } from "../fetch-management";
 import {
   ManagementCredentials,
-  Send2FaVerificationCodeInput,
-  Send2FaVerificationCodeResult,
+  SendTwoFAVerificationCodeInput,
+  SendTwoFAVerificationCodeResult,
 } from "../types";
 
-const SEND_2FA_VERIFICATION_CODE_MUTATION = gql`
-  mutation send2FaVerificationCode(
+const SEND_TWO_FA_VERIFICATION_CODE_MUTATION = gql`
+  mutation sendTwoFAVerificationCode(
     $callbackUrl: String!
     $identity: IdentityInput!
     $localeCodeOverride: String
@@ -37,17 +37,17 @@ const SEND_2FA_VERIFICATION_CODE_MUTATION = gql`
   }
 `;
 
-async function send2FaVerificationCode(
+async function sendTwoFAVerificationCode(
   managementCredentials: ManagementCredentials,
   {
     callbackUrl,
     identity,
     userId,
     localeCodeOverride,
-  }: Send2FaVerificationCodeInput,
-): Promise<Send2FaVerificationCodeResult> {
+  }: SendTwoFAVerificationCodeInput,
+): Promise<SendTwoFAVerificationCodeResult> {
   const operation = {
-    query: SEND_2FA_VERIFICATION_CODE_MUTATION,
+    query: SEND_TWO_FA_VERIFICATION_CODE_MUTATION,
     variables: {
       callbackUrl,
       identity,
@@ -57,7 +57,7 @@ async function send2FaVerificationCode(
   };
 
   const { data, errors } = await fetchManagement<{
-    sendPhoneVerificationCode: Send2FaVerificationCodeResult;
+    sendPhoneVerificationCode: SendTwoFAVerificationCodeResult;
   }>(managementCredentials, operation);
 
   if (errors) {
@@ -93,4 +93,4 @@ async function send2FaVerificationCode(
   return data.sendPhoneVerificationCode;
 }
 
-export { send2FaVerificationCode };
+export { sendTwoFAVerificationCode };

--- a/management/src/types.ts
+++ b/management/src/types.ts
@@ -120,14 +120,14 @@ type CheckVerificationCodeResult = {
   status: CheckVerificationCodeStatus;
 };
 
-type Send2FaVerificationCodeInput = {
+type SendTwoFAVerificationCodeInput = {
   callbackUrl: string;
   identity: IdentityInput;
   userId: string;
   localeCodeOverride?: string;
 };
 
-type Send2FaVerificationCodeResult = {
+type SendTwoFAVerificationCodeResult = {
   callbackUrl: string;
   eventId: string;
   localeCode: string;
@@ -148,8 +148,8 @@ export type {
   SendIdentityValidationCodeResult,
   CheckVerificationCodeInput,
   CheckVerificationCodeResult,
-  Send2FaVerificationCodeResult,
-  Send2FaVerificationCodeInput,
+  SendTwoFAVerificationCodeResult,
+  SendTwoFAVerificationCodeInput,
 };
 
 export { IdentityTypes, IdentityStatus, CheckVerificationCodeStatus };

--- a/management/tests/commands/index.test.ts
+++ b/management/tests/commands/index.test.ts
@@ -8,7 +8,7 @@ import {
   sendIdentityValidationCode,
   updateProviderApplication,
   updateIdentityFromUser,
-  send2FaVerificationCode,
+  sendTwoFAVerificationCode,
 } from "../../index";
 
 describe("Commands", () => {
@@ -22,6 +22,6 @@ describe("Commands", () => {
     expect(sendIdentityValidationCode).toBeInstanceOf(Function);
     expect(updateProviderApplication).toBeInstanceOf(Function);
     expect(updateIdentityFromUser).toBeInstanceOf(Function);
-    expect(send2FaVerificationCode).toBeInstanceOf(Function);
+    expect(sendTwoFAVerificationCode).toBeInstanceOf(Function);
   });
 });


### PR DESCRIPTION
This Pr simply renames `send2FaVerificationCode` to `sendTwoFAVerificationCode`. 