### PR TITLE
Added `IdentityNotFoundError` in `getIdentity`

### DIFF
--- a/management/CHANGELOG.md
+++ b/management/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.3] - 2021-04-09
+
+- `getIdentity` now throws `NotIdentityFoundError` if no Identity is found.
+
 ## [0.6.2] - 2021-03-24
 
 - Fixed `getUserIdFromIdentityValue`.

--- a/management/package.json
+++ b/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-management",
-  "version": "0.0.0-experimental-7a6f3cc",
+  "version": "0.6.3",
   "author": "Fewlines",
   "description": "Management flow for the Connect JS SDK",
   "license": "MIT",

--- a/management/package.json
+++ b/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-management",
-  "version": "0.0.0-experimental-2c54828",
+  "version": "0.0.0-experimental-7a6f3cc",
   "author": "Fewlines",
   "description": "Management flow for the Connect JS SDK",
   "license": "MIT",

--- a/management/package.json
+++ b/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-management",
-  "version": "0.6.2",
+  "version": "0.0.0-experimental-2fb6842",
   "author": "Fewlines",
   "description": "Management flow for the Connect JS SDK",
   "license": "MIT",

--- a/management/package.json
+++ b/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-management",
-  "version": "0.0.0-experimental-4179943",
+  "version": "0.0.0-experimental-2c54828",
   "author": "Fewlines",
   "description": "Management flow for the Connect JS SDK",
   "license": "MIT",

--- a/management/package.json
+++ b/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-management",
-  "version": "0.0.0-experimental-2fb6842",
+  "version": "0.0.0-experimental-4179943",
   "author": "Fewlines",
   "description": "Management flow for the Connect JS SDK",
   "license": "MIT",

--- a/management/src/commands/update-identity-from-user.ts
+++ b/management/src/commands/update-identity-from-user.ts
@@ -1,4 +1,3 @@
-import { IdentityNotFoundError } from "../errors";
 import { getIdentity } from "../queries/get-identity";
 import { ManagementCredentials } from "../types";
 import { getIdentityType } from "../utils/get-identity-type";
@@ -18,10 +17,6 @@ async function updateIdentityFromUser(
     userId,
     identityId: identityToUpdateId,
   });
-
-  if (!identityToUpdate) {
-    throw new IdentityNotFoundError();
-  }
 
   const { id: identityId } = await addIdentityToUser(
     managementCredentials,

--- a/management/src/queries/get-identity.ts
+++ b/management/src/queries/get-identity.ts
@@ -1,6 +1,10 @@
 import gql from "graphql-tag";
 
-import { GraphqlErrors, OutputDataNullError } from "../errors";
+import {
+  GraphqlErrors,
+  IdentityNotFoundError,
+  OutputDataNullError,
+} from "../errors";
 import { fetchManagement } from "../fetch-management";
 import { Identity, ManagementCredentials } from "../types";
 
@@ -43,6 +47,14 @@ async function getIdentity(
   }>(managementCredentials, operation);
 
   if (errors) {
+    const isIdentityNotFoundError = errors.some((error) => {
+      return error.message === "identity not found";
+    });
+
+    if (isIdentityNotFoundError) {
+      throw new IdentityNotFoundError();
+    }
+
     throw new GraphqlErrors(errors);
   }
 


### PR DESCRIPTION
This PR aims at fine-tuning the error flow inside `getIdentity` to throw a `404` instead of a `500` by separating it from `GraphQLErrors`.