### PR TITLE
Adding new getUserInfo method on oauth2Client

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.0] - 2021-04-19
+
+- New method to fetch Provider's `/userinfo` endpoint (`getUserInfo`).
+
 ## [0.4.2] - 2021-04-12
 
 ### Changes
@@ -113,7 +117,7 @@ All notable changes to this project will be documented in this file.
 
 #### Major
 
-```
+```sh
   @typescript-eslint/eslint-plugin  dev    ~3mo  3.10.1  →  4.9.0   ~7d
   @typescript-eslint/parser         dev    ~3mo  3.10.1  →  4.9.0   ~7d
   eslint-config-prettier            dev    ~1mo  6.15.0  →  7.0.0   ~2d
@@ -123,7 +127,7 @@ All notable changes to this project will be documented in this file.
 
 #### Minor
 
-```
+```sh
   @types/node                       dev     ~5mo  14.0.26  →  14.14.10  ~12d
   @typescript-eslint/eslint-plugin  dev     ~5mo    3.7.0  →    3.10.1  ~3mo
   @typescript-eslint/parser         dev     ~5mo    3.7.0  →    3.10.1  ~3mo

--- a/client/README.md
+++ b/client/README.md
@@ -67,14 +67,14 @@ Returns a list containing the `access_token`, `refresh_token`, and `id_token` if
 
 ```typescript
 const tokens = await oauthClient.getTokensFromAuthorizationCode(
-  "authorization_code",
+  "authorization_code"
 );
 ```
 
 ### verifyJWT
 
 ```typescript
-async verifyJWT<T = unknown>(accessToken: string, algo: string): Promise<T> {};
+async verifyJWT<T = unknown>(accessToken: string, algo: string): Promise<T> {}
 ```
 
 Used to verify the JWS (i.e. `access_token`). It provides a series of checks, like audiences, algorithm or public key.
@@ -101,7 +101,7 @@ const decrypted = oauthClient.decryptJWE<string>(JWE, privateKey, true);
 const decrypted = oauthClient.decryptJWE<{ [key: string]: string }>(
   JWE,
   privateKey,
-  false,
+  false
 );
 ```
 
@@ -115,8 +115,22 @@ Returns a refreshed `access_token` along with a new `refresh_token`.
 
 ```typescript
 const { refresh_token, access_token } = await oauthClient.refreshTokens(
-  "refresh_token",
+  refresh_token
 );
+```
+
+### getUserInfo
+
+**_ This method is still a work in progress _**
+
+```typescript
+async getUserInfo(accessToken: string): Promise<Record<string, unknown>>
+```
+
+Returns the JSON response from the Provider's `/userinfo` endpoint fetching, concerning the user associated with the `access_token` provided in parameter.
+
+```typescript
+const userInfoResponse = await oauthClient.getUserInfo(accessToken);
 ```
 
 ## Utils

--- a/client/README.md
+++ b/client/README.md
@@ -67,7 +67,7 @@ Returns a list containing the `access_token`, `refresh_token`, and `id_token` if
 
 ```typescript
 const tokens = await oauthClient.getTokensFromAuthorizationCode(
-  "authorization_code"
+  "authorization_code",
 );
 ```
 
@@ -101,7 +101,7 @@ const decrypted = oauthClient.decryptJWE<string>(JWE, privateKey, true);
 const decrypted = oauthClient.decryptJWE<{ [key: string]: string }>(
   JWE,
   privateKey,
-  false
+  false,
 );
 ```
 
@@ -115,7 +115,7 @@ Returns a refreshed `access_token` along with a new `refresh_token`.
 
 ```typescript
 const { refresh_token, access_token } = await oauthClient.refreshTokens(
-  refresh_token
+  refresh_token,
 );
 ```
 

--- a/client/index.ts
+++ b/client/index.ts
@@ -207,7 +207,7 @@ class OAuth2Client {
     };
 
     const tokenEndpointResponse = await this.fetch(
-      openIDConfiguration.token_endpoint,
+      openIDConfiguration.userinfo_endpoint,
       {
         method: "POST",
         headers: {
@@ -305,6 +305,25 @@ class OAuth2Client {
         "Content-Type": "application/x-www-form-urlencoded",
       },
       body: new URLSearchParams(payload),
+    })
+      .then((response) => response.json())
+      .catch((error) => {
+        if (error instanceof FetchError) {
+          throw new UnreachableError(error);
+        }
+
+        throw error;
+      });
+  }
+
+  async getUserInfo(accessToken: string): Promise<Record<string, unknown>> {
+    const openIDConfiguration = await this.getOpenIDConfiguration();
+
+    return await this.fetch(openIDConfiguration.userinfo_endpoint, {
+      method: "GET",
+      headers: {
+        Authorization: "Bearer " + accessToken,
+      },
     })
       .then((response) => response.json())
       .catch((error) => {


### PR DESCRIPTION
Title.

For now, since we are not totally sure of what we will receive from this endpoint regarding profile and address, we simply return the whole JSON response body. We will fine tune this later. 