### PR TITLE
Adding new util function to generate JWE

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [0.4.4] - 2021-04-26
 
-- Fixing issue with `getTokensFromAuthorizationCode`.
-- Added new util function to generate JWE (`generateJWE`).
+- Fixed an issue with `getTokensFromAuthorizationCode`.
+- Added a new util function to generate JWE (`generateJWE`).
 
 ## [0.4.3] - 2021-04-19
 

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.4] - 2021-04-26
+
+- Fixing issue with `getTokensFromAuthorizationCode`.
+- Added new util function to generate JWE (`generateJWE`).
+
 ## [0.4.3] - 2021-04-19
 
 - New method to fetch Provider's `/userinfo` endpoint (`getUserInfo`).
@@ -106,8 +111,8 @@ All notable changes to this project will be documented in this file.
 ### Changes
 
 - Added two new functions to generate JWS:
-  - generateHS256JWS
-  - generateRS256JWS
+  - `generateHS256JWS`
+  - `generateRS256JWS`
 - The package now export the following default object to help tests writing:
   - `defaultPayload` - Default JWT payload.
   - `asymmetricAlgoKeyPair` - Default pair of private and public key used for **RS256**.

--- a/client/README.md
+++ b/client/README.md
@@ -67,7 +67,7 @@ Returns a list containing the `access_token`, `refresh_token`, and `id_token` if
 
 ```typescript
 const tokens = await oauthClient.getTokensFromAuthorizationCode(
-  "authorization_code",
+  "authorization_code"
 );
 ```
 
@@ -101,7 +101,7 @@ const decrypted = oauthClient.decryptJWE<string>(JWE, privateKey, true);
 const decrypted = oauthClient.decryptJWE<{ [key: string]: string }>(
   JWE,
   privateKey,
-  false,
+  false
 );
 ```
 
@@ -115,7 +115,7 @@ Returns a refreshed `access_token` along with a new `refresh_token`.
 
 ```typescript
 const { refresh_token, access_token } = await oauthClient.refreshTokens(
-  refresh_token,
+  refresh_token
 );
 ```
 
@@ -160,6 +160,16 @@ generateRS256JWS(customPayload?: CustomPayload, secret?: string): string {};
 If used without any argument, the function will return a default **RS256 JWS** composed of the default objects found below.
 
 You can give a custom **secret** for signature, and/or a custom payload to customize your **RS256 JWS**.
+
+### generateJWE
+
+```typescript
+import { generateJWE } from "@fewlines/connect-client"
+
+await generateJWE(jwtOrJws: string, publicKey: string): Promise<string> {};
+```
+
+Given a signed or not JWT and a RSA public key, this function will return a JWE.
 
 ### default JWS composition objects
 

--- a/client/README.md
+++ b/client/README.md
@@ -166,10 +166,14 @@ You can give a custom **secret** for signature, and/or a custom payload to custo
 ```typescript
 import { generateJWE } from "@fewlines/connect-client"
 
-await generateJWE(JWTPayloadOrJWS: JWTPayload | string, publicKey: string): Promise<string> {};
+await generateJWE(
+  JWTPayload: JWTPayload,
+  publicKeyForEncryption: string,
+  options?: { secretKey?: string; privateKeyForSignature?: string }
+): Promise<string> {};
 ```
 
-Given a signed or not JWT and a RSA public key, this function will return a JWE.
+This function takes as arguments a JWT payload, a RSA public key for encryption, and an optional object, `options`, containing either a secret key for signing a HS256 JWS, or a RSA private key for signing a RS256 JWS before encrypting it. It will then return a JWE based on a non-signed JWT or a JWS, according to arguments provided.
 
 ### default JWS composition objects
 

--- a/client/README.md
+++ b/client/README.md
@@ -67,7 +67,7 @@ Returns a list containing the `access_token`, `refresh_token`, and `id_token` if
 
 ```typescript
 const tokens = await oauthClient.getTokensFromAuthorizationCode(
-  "authorization_code"
+  "authorization_code",
 );
 ```
 
@@ -101,7 +101,7 @@ const decrypted = oauthClient.decryptJWE<string>(JWE, privateKey, true);
 const decrypted = oauthClient.decryptJWE<{ [key: string]: string }>(
   JWE,
   privateKey,
-  false
+  false,
 );
 ```
 
@@ -115,7 +115,7 @@ Returns a refreshed `access_token` along with a new `refresh_token`.
 
 ```typescript
 const { refresh_token, access_token } = await oauthClient.refreshTokens(
-  refresh_token
+  refresh_token,
 );
 ```
 

--- a/client/README.md
+++ b/client/README.md
@@ -166,7 +166,7 @@ You can give a custom **secret** for signature, and/or a custom payload to custo
 ```typescript
 import { generateJWE } from "@fewlines/connect-client"
 
-await generateJWE(jwtOrJws: string, publicKey: string): Promise<string> {};
+await generateJWE(JWTPayloadOrJWS: JWTPayload | string, publicKey: string): Promise<string> {};
 ```
 
 Given a signed or not JWT and a RSA public key, this function will return a JWE.

--- a/client/index.ts
+++ b/client/index.ts
@@ -207,7 +207,7 @@ class OAuth2Client {
     };
 
     const tokenEndpointResponse = await this.fetch(
-      openIDConfiguration.userinfo_endpoint,
+      openIDConfiguration.token_endpoint,
       {
         method: "POST",
         headers: {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-client",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "author": "Fewlines",
   "description": "OAuth2 Client for the Connect JS SDK",
   "license": "MIT",

--- a/client/src/utils/generateJWE.ts
+++ b/client/src/utils/generateJWE.ts
@@ -1,26 +1,34 @@
 import jose from "node-jose";
 
 import { JWTPayload } from "../types";
+import { generateHS256JWS, generateRS256JWS } from "./generateJWS";
 
 async function generateJWE(
-  JWTPayloadOrJWS: JWTPayload | string,
-  publicKey: string,
+  JWTPayload: JWTPayload,
+  publicKeyForEncryption: string,
+  options?: { secretKey?: string; privateKeyForSignature?: string },
 ): Promise<string> {
-  const josePublicKeyForEncryption = await jose.JWK.asKey(publicKey, "pem");
+  const josePublicKeyForEncryption = await jose.JWK.asKey(
+    publicKeyForEncryption,
+    "pem",
+  );
 
-  let JWTOrJWS;
+  let JWSToken;
 
-  if (typeof JWTPayloadOrJWS === "string") {
-    JWTOrJWS = Buffer.from(JWTPayloadOrJWS);
-  } else {
-    JWTOrJWS = JSON.stringify(JWTPayloadOrJWS);
+  if (options) {
+    if (options.secretKey) {
+      JWSToken = generateHS256JWS(JWTPayload, options.secretKey);
+    }
+    if (options.privateKeyForSignature) {
+      JWSToken = generateRS256JWS(JWTPayload, options.privateKeyForSignature);
+    }
   }
 
   return await jose.JWE.createEncrypt(
     { format: "compact" },
     josePublicKeyForEncryption,
   )
-    .update(Buffer.from(JWTOrJWS))
+    .update(Buffer.from(options ? JWSToken : JSON.stringify(JWTPayload)))
     .final();
 }
 

--- a/client/src/utils/generateJWE.ts
+++ b/client/src/utils/generateJWE.ts
@@ -1,0 +1,17 @@
+import jose from "node-jose";
+
+async function generateJWE(
+  jwtOrJws: string,
+  publicKey: string,
+): Promise<string> {
+  const josePublicKeyForEncryption = await jose.JWK.asKey(publicKey, "pem");
+
+  return await jose.JWE.createEncrypt(
+    { format: "compact" },
+    josePublicKeyForEncryption,
+  )
+    .update(Buffer.from(jwtOrJws))
+    .final();
+}
+
+export { generateJWE };

--- a/client/src/utils/generateJWE.ts
+++ b/client/src/utils/generateJWE.ts
@@ -1,16 +1,26 @@
 import jose from "node-jose";
 
+import { JWTPayload } from "../types";
+
 async function generateJWE(
-  jwtOrJws: string,
+  JWTPayloadOrJWS: JWTPayload | string,
   publicKey: string,
 ): Promise<string> {
   const josePublicKeyForEncryption = await jose.JWK.asKey(publicKey, "pem");
+
+  let JWTOrJWS;
+
+  if (typeof JWTPayloadOrJWS === "string") {
+    JWTOrJWS = Buffer.from(JWTPayloadOrJWS);
+  } else {
+    JWTOrJWS = JSON.stringify(JWTPayloadOrJWS);
+  }
 
   return await jose.JWE.createEncrypt(
     { format: "compact" },
     josePublicKeyForEncryption,
   )
-    .update(Buffer.from(jwtOrJws))
+    .update(Buffer.from(JWTOrJWS))
     .final();
 }
 

--- a/client/tests/generateJWE.test.ts
+++ b/client/tests/generateJWE.test.ts
@@ -1,0 +1,30 @@
+import crypto from "crypto";
+
+import { generateJWE } from "../src/utils/generateJWE";
+import { generateRS256JWS } from "../src/utils/generateJWS";
+
+describe("generateJWE", () => {
+  const RS256JWT = generateRS256JWS();
+
+  test("should generate a JWE", async () => {
+    expect.assertions(1);
+    const { publicKey: publicKeyForEncryption } = crypto.generateKeyPairSync(
+      "rsa",
+      {
+        modulusLength: 2048,
+        publicKeyEncoding: {
+          type: "spki",
+          format: "pem",
+        },
+        privateKeyEncoding: {
+          type: "pkcs8",
+          format: "pem",
+        },
+      },
+    );
+
+    const generatedJWE = await generateJWE(RS256JWT, publicKeyForEncryption);
+
+    expect(generatedJWE.split(".").length).toEqual(5);
+  });
+});

--- a/client/tests/generateJWE.test.ts
+++ b/client/tests/generateJWE.test.ts
@@ -1,13 +1,15 @@
 import crypto from "crypto";
 
+import { defaultPayload } from "../src/utils/defaultObjects";
 import { generateJWE } from "../src/utils/generateJWE";
 import { generateRS256JWS } from "../src/utils/generateJWS";
 
 describe("generateJWE", () => {
   const RS256JWT = generateRS256JWS();
 
-  test("should generate a JWE", async () => {
+  test("should generate a JWE from a JWS", async () => {
     expect.assertions(1);
+
     const { publicKey: publicKeyForEncryption } = crypto.generateKeyPairSync(
       "rsa",
       {
@@ -24,6 +26,32 @@ describe("generateJWE", () => {
     );
 
     const generatedJWE = await generateJWE(RS256JWT, publicKeyForEncryption);
+
+    expect(generatedJWE.split(".").length).toEqual(5);
+  });
+
+  test("should generate a JWE from a JWT", async () => {
+    expect.assertions(1);
+
+    const { publicKey: publicKeyForEncryption } = crypto.generateKeyPairSync(
+      "rsa",
+      {
+        modulusLength: 2048,
+        publicKeyEncoding: {
+          type: "spki",
+          format: "pem",
+        },
+        privateKeyEncoding: {
+          type: "pkcs8",
+          format: "pem",
+        },
+      },
+    );
+
+    const generatedJWE = await generateJWE(
+      defaultPayload,
+      publicKeyForEncryption,
+    );
 
     expect(generatedJWE.split(".").length).toEqual(5);
   });

--- a/client/tests/generateJWE.test.ts
+++ b/client/tests/generateJWE.test.ts
@@ -1,13 +1,10 @@
 import crypto from "crypto";
 
-import { defaultPayload } from "../src/utils/defaultObjects";
+import { defaultPayload, defaultSecret } from "../src/utils/defaultObjects";
 import { generateJWE } from "../src/utils/generateJWE";
-import { generateRS256JWS } from "../src/utils/generateJWS";
 
 describe("generateJWE", () => {
-  const RS256JWT = generateRS256JWS();
-
-  test("should generate a JWE from a JWS", async () => {
+  test("should generate a JWE from a HS256 JWS", async () => {
     expect.assertions(1);
 
     const { publicKey: publicKeyForEncryption } = crypto.generateKeyPairSync(
@@ -25,7 +22,53 @@ describe("generateJWE", () => {
       },
     );
 
-    const generatedJWE = await generateJWE(RS256JWT, publicKeyForEncryption);
+    const generatedJWE = await generateJWE(
+      defaultPayload,
+      publicKeyForEncryption,
+      { secretKey: defaultSecret },
+    );
+
+    expect(generatedJWE.split(".").length).toEqual(5);
+  });
+
+  test("should generate a JWE from a RS256 JWS", async () => {
+    expect.assertions(1);
+
+    const { privateKey: privateKeyForSignature } = crypto.generateKeyPairSync(
+      "rsa",
+      {
+        modulusLength: 2048,
+        publicKeyEncoding: {
+          type: "spki",
+          format: "pem",
+        },
+        privateKeyEncoding: {
+          type: "pkcs8",
+          format: "pem",
+        },
+      },
+    );
+
+    const { publicKey: publicKeyForEncryption } = crypto.generateKeyPairSync(
+      "rsa",
+      {
+        modulusLength: 2048,
+        publicKeyEncoding: {
+          type: "spki",
+          format: "pem",
+        },
+        privateKeyEncoding: {
+          type: "pkcs8",
+          format: "pem",
+        },
+      },
+    );
+
+    const generatedJWE = await generateJWE(
+      defaultPayload,
+      publicKeyForEncryption,
+      { privateKeyForSignature },
+    );
 
     expect(generatedJWE.split(".").length).toEqual(5);
   });

--- a/client/tests/index.test.ts
+++ b/client/tests/index.test.ts
@@ -469,12 +469,10 @@ describe("OAuth2Client", () => {
         true,
       );
 
-      console.log("signed: ", decryptedMockedJWEWithJWS);
-
       expect(decryptedMockedJWEWithJWS).toStrictEqual(mockedSignedJWT);
     });
 
-    test.only("it should correctly decrypt a JWE based on non-signed JWT", async () => {
+    test("it should correctly decrypt a JWE based on non-signed JWT", async () => {
       expect.assertions(1);
 
       const oauthClient = new OAuth2Client(oauthClientConstructorProps);

--- a/client/tests/index.test.ts
+++ b/client/tests/index.test.ts
@@ -16,6 +16,7 @@ import OAuth2Client, {
   generateHS256JWS,
 } from "../index";
 import { generateJWE } from "../src/utils/generateJWE";
+import { generateRS256JWS } from "../src/utils/generateJWS";
 
 enableFetchMocks();
 
@@ -423,7 +424,6 @@ describe("OAuth2Client", () => {
 
       const oauthClient = new OAuth2Client(oauthClientConstructorProps);
 
-      const passphraseSignature = "top secret";
       const { privateKey: privateKeyForSignature } = crypto.generateKeyPairSync(
         "rsa",
         {
@@ -435,8 +435,6 @@ describe("OAuth2Client", () => {
           privateKeyEncoding: {
             type: "pkcs8",
             format: "pem",
-            cipher: "aes-256-cbc",
-            passphrase: passphraseSignature,
           },
         },
       );
@@ -456,11 +454,15 @@ describe("OAuth2Client", () => {
         },
       });
 
-      const mockedSignedJWT = jwt.sign(defaultPayload, privateKeyForSignature);
+      const mockedSignedJWT = generateRS256JWS(
+        defaultPayload,
+        privateKeyForSignature,
+      );
 
       const mockedJWEWithJWS = await generateJWE(
-        mockedSignedJWT,
+        defaultPayload,
         publicKeyForEncryption,
+        { privateKeyForSignature },
       );
 
       const decryptedMockedJWEWithJWS = await oauthClient.decryptJWE<string>(

--- a/client/tests/index.test.ts
+++ b/client/tests/index.test.ts
@@ -2,7 +2,6 @@ import crypto from "crypto";
 import fetch from "jest-fetch-mock";
 import { enableFetchMocks } from "jest-fetch-mock";
 import jwt, { JsonWebTokenError } from "jsonwebtoken";
-import jose from "node-jose";
 
 import OAuth2Client, {
   InvalidAudienceError,
@@ -16,6 +15,7 @@ import OAuth2Client, {
   OpenIDConfiguration,
   generateHS256JWS,
 } from "../index";
+import { generateJWE } from "../src/utils/generateJWE";
 
 enableFetchMocks();
 
@@ -458,17 +458,10 @@ describe("OAuth2Client", () => {
 
       const mockedSignedJWT = jwt.sign(defaultPayload, privateKeyForSignature);
 
-      const josePublicKeyForEncryption = await jose.JWK.asKey(
+      const mockedJWEWithJWS = await generateJWE(
+        mockedSignedJWT,
         publicKeyForEncryption,
-        "pem",
       );
-
-      const mockedJWEWithJWS = await jose.JWE.createEncrypt(
-        { format: "compact" },
-        josePublicKeyForEncryption,
-      )
-        .update(Buffer.from(mockedSignedJWT))
-        .final();
 
       const decryptedMockedJWEWithJWS = await oauthClient.decryptJWE<string>(
         mockedJWEWithJWS,


### PR DESCRIPTION
I added a new util function to generate JWE. 
It takes as argument a signed or not JWT and a public key to perform encryption, and return the JWE. It is very basic function. Let me know if it meets your needs, or if it needs more customization. 


EDIT: The first version didn't properly handled non-signed JWT. I changed the argument `JWTPayloadOrJWS`type to support a JWT payload or a string (JWS), and did the changes inside the function regarding the type of this argument. 