### PR TITLE
Fix third party auth

### DIFF
--- a/popup/CHANGELOG.md
+++ b/popup/CHANGELOG.md
@@ -1,0 +1,7 @@
+## 0.2.0 - 2021-08-17
+
+- Third Party authentication is now supported but nothing change for the usage of this library.
+
+## 0.1.0
+
+- First version

--- a/popup/package.json
+++ b/popup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-popup",
-  "version": "0.0.0-experimental-a194499",
+  "version": "0.2.0",
   "description": "Library to use Connect in a Popup",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/popup/package.json
+++ b/popup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-popup",
-  "version": "0.0.0-experimental-b764167",
+  "version": "0.2.0",
   "description": "Library to use Connect in a Popup",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -39,7 +39,7 @@
   "scripts": {
     "build": "tsc && yarn rollup && yarn build-example",
     "build-example": "cp ./dist/connect-popup.min.js{,.map} example/",
-    "experimental-publish": "yarn publish --new-version \"0.0.0-experimental-$(git rev-parse --short HEAD)\" --access public --tag experimental",
+    "experimental-publish": "yarn build && npm publish --new-version \"0.0.0-experimental-$(git rev-parse --short HEAD)\" --access public --tag experimental",
     "lint": "eslint --ext .js,.ts --ignore-pattern dist .",
     "rollup": "rollup -c"
   }

--- a/popup/package.json
+++ b/popup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-popup",
-  "version": "0.2.0",
+  "version": "0.0.0-experimental-a194499",
   "description": "Library to use Connect in a Popup",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -39,7 +39,7 @@
   "scripts": {
     "build": "tsc && yarn rollup && yarn build-example",
     "build-example": "cp ./dist/connect-popup.min.js{,.map} example/",
-    "experimental-publish": "yarn build && npm publish --new-version \"0.0.0-experimental-$(git rev-parse --short HEAD)\" --access public --tag experimental",
+    "experimental-publish": "yarn build && yarn publish --new-version \"0.0.0-experimental-$(git rev-parse --short HEAD)\" --access public --tag experimental",
     "lint": "eslint --ext .js,.ts --ignore-pattern dist .",
     "rollup": "rollup -c"
   }

--- a/popup/package.json
+++ b/popup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-popup",
-  "version": "0.1.0",
+  "version": "0.0.0-experimental-b764167",
   "description": "Library to use Connect in a Popup",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/popup/src/index.ts
+++ b/popup/src/index.ts
@@ -22,6 +22,11 @@ type Options = {
   onAuthorizationCodeReceived?: AuthorizationCodeCallback;
 };
 
+
+function utf8_to_b64( str: string ): string {
+  return window.btoa(unescape(encodeURIComponent( str )));
+}
+
 class ConnectPopup {
   private popupOptions: PopupOptions = { width: 450 };
   private connectOptions: connectOptions;
@@ -29,6 +34,7 @@ class ConnectPopup {
     onAuthorizationCodeReceived?: AuthorizationCodeCallback;
   } = {};
   private popup: Window;
+  private version = 1;
 
   constructor(options: Options) {
     if (options.popup) {
@@ -70,12 +76,21 @@ class ConnectPopup {
         this.popupOptions.left || window.screen.width / 2 - width / 2;
 
       const currentUrl = window.location.protocol + "//" + window.location.host;
-      let url = `${this.connectOptions.providerURL}/oauth/popup?client_id=${this.connectOptions.clientId}&scope=${this.connectOptions.scopes}&caller_uri=${currentUrl}`;
-      if (state) {
-        url += `&state=${state}`;
-      }
+
+      const connectUrl = new URL(this.connectOptions.providerURL + "/oauth/authorize")
+      connectUrl.searchParams.append("client_id", this.connectOptions.clientId)
+      connectUrl.searchParams.append("redirect_uri", this.connectOptions.providerURL + "/oauth/popup/callback")
+      connectUrl.searchParams.append("scope", this.connectOptions.scopes)
+      connectUrl.searchParams.append("response_type", "code")
+      const newState = utf8_to_b64(JSON.stringify({
+          state,
+          current_url: currentUrl,
+          v: this.version,
+      }))
+      connectUrl.searchParams.append("state", newState)
+
       const popup = window.open(
-        url,
+        connectUrl.toString(),
         "connect-popup",
         `menubar=no,location=yes,resizable=yes,scrollbars=yes,status=yes,width=${width},height=${height},top=${top},left=${left}`,
       );

--- a/popup/src/index.ts
+++ b/popup/src/index.ts
@@ -22,9 +22,8 @@ type Options = {
   onAuthorizationCodeReceived?: AuthorizationCodeCallback;
 };
 
-
-function utf8_to_b64( str: string ): string {
-  return window.btoa(unescape(encodeURIComponent( str )));
+function utf8_to_b64(str: string): string {
+  return window.btoa(unescape(encodeURIComponent(str)));
 }
 
 class ConnectPopup {
@@ -77,17 +76,24 @@ class ConnectPopup {
 
       const currentUrl = window.location.protocol + "//" + window.location.host;
 
-      const connectUrl = new URL(this.connectOptions.providerURL + "/oauth/authorize")
-      connectUrl.searchParams.append("client_id", this.connectOptions.clientId)
-      connectUrl.searchParams.append("redirect_uri", this.connectOptions.providerURL + "/oauth/popup/callback")
-      connectUrl.searchParams.append("scope", this.connectOptions.scopes)
-      connectUrl.searchParams.append("response_type", "code")
-      const newState = utf8_to_b64(JSON.stringify({
-          state,
+      const connectUrl = new URL(
+        this.connectOptions.providerURL + "/oauth/authorize",
+      );
+      connectUrl.searchParams.append("client_id", this.connectOptions.clientId);
+      connectUrl.searchParams.append(
+        "redirect_uri",
+        this.connectOptions.providerURL + "/oauth/popup/callback",
+      );
+      connectUrl.searchParams.append("scope", this.connectOptions.scopes);
+      connectUrl.searchParams.append("response_type", "code");
+      const newState = utf8_to_b64(
+        JSON.stringify({
+          state: state || "",
           current_url: currentUrl,
           v: this.version,
-      }))
-      connectUrl.searchParams.append("state", newState)
+        }),
+      );
+      connectUrl.searchParams.append("state", newState);
 
       const popup = window.open(
         connectUrl.toString(),


### PR DESCRIPTION
## Description

This PR updates the way the popup works to allow third party authentication.

Before, we opened an URL on Connect OAuth that opened an iframe with the authorization flow.
Now, we open directly the authorization flow by wrapping the state in a JSON object, converted to base64 to pass along the domain of the popup parent in order to let the last page of the authorization flow pass the authorization code to the parent.

## Motivation and Context

We want the popup to be seamless and to work as well as the normal flow.

## How Has This Been Tested?

Locally but intensely

## Types of changes

- [ ] Chore (non-breaking change which refactors / improves the existing code base)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My change requires a change to a package version.
- [x] I have updated the `package.json` version accordingly.
- [x] I have updated the `CHANGELOG.md` version accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
