### PR TITLE
CU-1kjd67v-Connect-client-Update-verifyJWT-to-take-an-optional-audience-parameter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,18 +4,18 @@ jobs:
   select-jobs-to-run:
     docker:
       - image: cimg/node:14.17.0
-    steps: 
+    steps:
       - checkout
       - run: git diff --no-commit-id --name-only -r `git log -n 2 --oneline --pretty=format:"%h" | tail -n1` | cut -d/ -f1 | sort -u > manifest.txt
       - run: cat manifest.txt
       - persist_to_workspace:
           root: ./
-          paths: 
+          paths:
             - manifest.txt
 
   lint-and-tests:
     parameters:
-      package: 
+      package:
         type: string
     working_directory: ~/project/<< parameters.package >>
     docker:
@@ -25,7 +25,7 @@ jobs:
           path: ~/project
       - attach_workspace:
           at: /tmp/workspace
-      - run: 
+      - run:
           name: Check if the job need to be run
           command: |
             manifestPath=/tmp/workspace/manifest.txt
@@ -44,30 +44,30 @@ jobs:
       - run:
           name: Run lint
           command: yarn lint
-      - unless: 
+      - unless:
           condition:
             equal: ["popup", << parameters.package >>]
-          steps: 
-            - run: 
+          steps:
+            - run:
                 name: Run tests
                 command: yarn test
 
 workflows:
-  lint-and-tests: 
+  lint-and-tests:
     jobs:
       - select-jobs-to-run
       - lint-and-tests:
           name: client-lint-and-tests
           package: client
-          requires: 
+          requires:
             - select-jobs-to-run
       - lint-and-tests:
           name: management-lint-and-tests
           package: management
-          requires: 
+          requires:
             - select-jobs-to-run
       - lint-and-tests:
           name: popup-lint
           package: popup
-          requires: 
+          requires:
             - select-jobs-to-run

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -23,6 +23,10 @@ All notable changes to this project will be documented in this file.
   @types/node-jose                  dev    ~11mo     1.1.5  →   1.1.8  ~2mo
 ```
 
+## [0.5.2] - 2021-11-15
+
+- Updated `verifyJWT` to add the optional audience parameter.
+
 ## [0.5.1] - 2021-06-15
 
 - Updated `JWTPayload` type to allow optional claims.

--- a/client/README.md
+++ b/client/README.md
@@ -74,10 +74,10 @@ const tokens = await oauthClient.getTokensFromAuthorizationCode(
 ### verifyJWT
 
 ```typescript
-async verifyJWT<T = unknown>(accessToken: string, algo: string): Promise<T> {}
+async verifyJWT<T = unknown>(accessToken: string, algo: string, audience?: string): Promise<T> {}
 ```
 
-Used to verify the JWS (i.e. `access_token`). It provides a series of checks, like audiences, algorithm or public key.
+Used to verify the JWS (i.e. `access_token`). It provides a series of checks, like audiences, algorithm or public key. The audience parameter is optional and will have a default value of the config audience.
 
 ```typescript
 const decoded = await oauthClient.verifyJWT(JWS, "RS256");

--- a/client/index.ts
+++ b/client/index.ts
@@ -288,7 +288,7 @@ class OAuth2Client {
     const { payload } = decryptedJWEToken;
 
     if (isSigned) {
-      return (payload.toString() as unknown) as T;
+      return payload.toString() as unknown as T;
     } else {
       return JSON.parse(payload.toString()) as T;
     }

--- a/client/index.ts
+++ b/client/index.ts
@@ -238,7 +238,11 @@ class OAuth2Client {
     return tokens;
   }
 
-  async verifyJWT<T = unknown>(accessToken: string, algo: string): Promise<T> {
+  async verifyJWT<T = unknown>(
+    accessToken: string,
+    algo: string,
+    audience = this.audience,
+  ): Promise<T> {
     const [header, payload] = accessToken.split(".");
 
     const { alg, kid } = decodeJWTPart<{ alg: string; kid: string }>(header);
@@ -247,8 +251,8 @@ class OAuth2Client {
     const jwks = kid && (await this.getJWKS());
 
     if (
-      (typeof aud === "string" && aud !== this.audience) ||
-      (Array.isArray(aud) && !aud.includes(this.audience))
+      (typeof aud === "string" && aud !== audience) ||
+      (Array.isArray(aud) && !aud.includes(audience))
     ) {
       throw new InvalidAudienceError("Invalid audience");
     }
@@ -284,7 +288,7 @@ class OAuth2Client {
     const { payload } = decryptedJWEToken;
 
     if (isSigned) {
-      return payload.toString() as unknown as T;
+      return (payload.toString() as unknown) as T;
     } else {
       return JSON.parse(payload.toString()) as T;
     }

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/connect-client",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": "Fewlines",
   "description": "OAuth2 Client for the Connect JS SDK",
   "license": "MIT",

--- a/client/tests/index.test.ts
+++ b/client/tests/index.test.ts
@@ -61,8 +61,7 @@ describe("OAuth2Client", () => {
         e: "AQAB",
         kty: "RSA",
         kid: "d6512f53-9774-4a58-830c-981886c8bb43",
-        n:
-          "y3M7JqY49JeL/ornP7ZY2QlO76akS36Rj1iKVSIlFH754NnqmtGwMrCVZzCWrc882trbGuDhml2psOmCIBjKBpnghNLBZALGNRelCqfV7Cy+EMrQvQ+UWbogT7xfPoL+VYjCZKTeXosfzMNMZFum/Vnk/vYBKilXZfQH1t4sohU=",
+        n: "y3M7JqY49JeL/ornP7ZY2QlO76akS36Rj1iKVSIlFH754NnqmtGwMrCVZzCWrc882trbGuDhml2psOmCIBjKBpnghNLBZALGNRelCqfV7Cy+EMrQvQ+UWbogT7xfPoL+VYjCZKTeXosfzMNMZFum/Vnk/vYBKilXZfQH1t4sohU=",
         alg: "RS256",
       },
     ],
@@ -304,8 +303,7 @@ describe("OAuth2Client", () => {
         const mockedDecodedJWT = {
           aud: ["connect-account"],
           exp: 2524651200,
-          iss:
-            "https://bs-provider.prod.connect.connect.aws.eu-west-2.k8s.fewlines.net",
+          iss: "https://bs-provider.prod.connect.connect.aws.eu-west-2.k8s.fewlines.net",
           scope: "profile email",
           sub: "c4b1cb59-1c50-494a-87e5-32a5fe6e7caa",
         };
@@ -326,8 +324,7 @@ describe("OAuth2Client", () => {
         const mockedDecodedJWT = {
           aud: ["connect-account"],
           exp: 2524651200,
-          iss:
-            "https://bs-provider.prod.connect.connect.aws.eu-west-2.k8s.fewlines.net",
+          iss: "https://bs-provider.prod.connect.connect.aws.eu-west-2.k8s.fewlines.net",
           scope: "profile email",
           sub: "c4b1cb59-1c50-494a-87e5-32a5fe6e7caa",
         };
@@ -370,8 +367,7 @@ describe("OAuth2Client", () => {
               e: "AQAB",
               kty: "RSA",
               kid: "wrongKid",
-              n:
-                "y3M7JqY49JeL/ornP7ZY2QlO76akS36Rj1iKVSIlFH754NnqmtGwMrCVZzCWrc882trbGuDhml2psOmCIBjKBpnghNLBZALGNRelCqfV7Cy+EMrQvQ+UWbogT7xfPoL+VYjCZKTeXosfzMNMZFum/Vnk/vYBKilXZfQH1t4sohU=",
+              n: "y3M7JqY49JeL/ornP7ZY2QlO76akS36Rj1iKVSIlFH754NnqmtGwMrCVZzCWrc882trbGuDhml2psOmCIBjKBpnghNLBZALGNRelCqfV7Cy+EMrQvQ+UWbogT7xfPoL+VYjCZKTeXosfzMNMZFum/Vnk/vYBKilXZfQH1t4sohU=",
               alg: "RS256",
             },
           ],
@@ -401,8 +397,7 @@ describe("OAuth2Client", () => {
         const mockedDecodedJWT = {
           aud: ["connect-account"],
           exp: 2524651200,
-          iss:
-            "https://bs-provider.prod.connect.connect.aws.eu-west-2.k8s.fewlines.net",
+          iss: "https://bs-provider.prod.connect.connect.aws.eu-west-2.k8s.fewlines.net",
           scope: "profile email",
           sub: "c4b1cb59-1c50-494a-87e5-32a5fe6e7caa",
         };
@@ -413,8 +408,7 @@ describe("OAuth2Client", () => {
               e: "AQAB",
               kty: "RSA",
               kid: "wrongKid",
-              n:
-                "y3M7JqY49JeL/ornP7ZY2QlO76akS36Rj1iKVSIlFH754NnqmtGwMrCVZzCWrc882trbGuDhml2psOmCIBjKBpnghNLBZALGNRelCqfV7Cy+EMrQvQ+UWbogT7xfPoL+VYjCZKTeXosfzMNMZFum/Vnk/vYBKilXZfQH1t4sohU=",
+              n: "y3M7JqY49JeL/ornP7ZY2QlO76akS36Rj1iKVSIlFH754NnqmtGwMrCVZzCWrc882trbGuDhml2psOmCIBjKBpnghNLBZALGNRelCqfV7Cy+EMrQvQ+UWbogT7xfPoL+VYjCZKTeXosfzMNMZFum/Vnk/vYBKilXZfQH1t4sohU=",
               alg: "RS256",
             },
           ],
@@ -528,11 +522,12 @@ describe("OAuth2Client", () => {
         publicKeyForEncryption,
       );
 
-      const decryptedMockedJWEAccessToken = await oauthClient.decryptJWE<string>(
-        mockedJWEWithJWTPayload,
-        privateKeyForEncryption,
-        false,
-      );
+      const decryptedMockedJWEAccessToken =
+        await oauthClient.decryptJWE<string>(
+          mockedJWEWithJWTPayload,
+          privateKeyForEncryption,
+          false,
+        );
 
       expect(decryptedMockedJWEAccessToken).toStrictEqual(defaultPayload);
     });

--- a/client/tests/index.test.ts
+++ b/client/tests/index.test.ts
@@ -351,7 +351,7 @@ describe("OAuth2Client", () => {
           .once(JSON.stringify(mockedJWKS));
 
         await oauthClient
-          .verifyJWT(RS256JWT, "RS256", "oauth2")
+          .verifyJWT(RS256JWT, "RS256", "wrong audience")
           .catch((error) => {
             expect(error).toBeInstanceOf(InvalidAudienceError);
             expect(error.message).toBe("Invalid audience");


### PR DESCRIPTION
## Description

This PR adds the `audience` optional parameter to `verifyJWT` (with a default value of the `config` `audience`) and its tests. 

## Motivation and Context

We need this in order to use the function in `sparta-monorepo`  with `auth0` and particularly with the `id_token` that has a different audience than the one we use in the `config.json`. 

## How Has This Been Tested?

I added some tests and it all passed.

```shell
➜  client git:(CU-1kjd67v-Connect-client-Update-verifyJWT-to-take-an-optional-audience-parameter) ✗ yarn test index.test.ts                                                                                                                                                                                                                            [15:28:51]
yarn run v1.22.5
$ jest index.test.ts
 PASS  tests/index.test.ts
  OAuth2Client
    getAuthorizationURL
      ✓ should initialize the openIDConfiguration (4 ms)
      ✓ it should return a valid auth URL (1 ms)
      ✓ it should add the state at the end of the query string
      ✓ is should throw an error if the provided scopes are not supported
    getTokensFromAuthorizationCode
      ✓ should initialize the openIDConfiguration (1 ms)
      ✓ should return the tokens from connect
    verifyJWT
      ✓ it should throw an error if wrong audience in the JWT (1 ms)
      ✓ it should throw an error if wrong audience in verifyJWT params (1 ms)
      HS256 signed JWT
        ✓ it should return the JWT payload if a well formed JWT and a client secret are provided (2 ms)
        ✓ it should return the JWT payload if a well formed JWT and all params are OK (1 ms)
        ✓ it should throw an error if using the wrong client secret (1 ms)
        ✓ it should throw an error if using a malformed JWT (1 ms)
      RS256 signed JWT
        ✓ it should return a decoded jwt if valid (2 ms)
        ✓ it should return a decoded jwt if valid & audience param OK (1 ms)
        ✓ it should return an error if wrong audience param (1 ms)
        ✓ it should throw an error if invalid key id (1 ms)
        ✓ it should refetch and get the new JWKS if first fetch fails (2 ms)
        ✓ it should throw an error if missing key id (17 ms)
        ✓ it should throw an error algo is != from RS256 or HS256 (1 ms)
    decrypt JWE
      ✓ it should correctly decrypt JWE based on a JWS (99 ms)
      ✓ it should correctly decrypt a JWE based on non-signed JWT (87 ms)

Test Suites: 1 passed, 1 total
Tests:       21 passed, 21 total
Snapshots:   0 total
Time:        2.326 s, estimated 3 s
Ran all test suites matching /index.test.ts/i.
✨  Done in 3.29s.
```

## Types of changes

<!--- What types of changes does your code introduce? Stroke -->
- [x] Chore (non-breaking change which refactors / improves the existing code base)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)

## Checklist:

<!--- If you're unsure about any of these, don't hesitate to ask. We're -->
<!--- here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] My change requires a change to a package version.
- [x] I have updated the `package.json` version accordingly.
- [x] I have updated the `CHANGELOG.md` version accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
